### PR TITLE
Fix @site -> site

### DIFF
--- a/webmention_io.rb
+++ b/webmention_io.rb
@@ -50,10 +50,10 @@ module Jekyll
       # post Jekyll commit 0c0aea3
       # https://github.com/jekyll/jekyll/commit/0c0aea3ad7d2605325d420a23d21729c5cf7cf88
       if defined? site.find_converter_instance
-        @converter = @site.find_converter_instance(::Jekyll::Converters::Markdown)
+        @converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
       # Prior to Jekyll commit 0c0aea3
       else
-        @converter = @site.getConverterImpl(::Jekyll::Converters::Markdown)
+        @converter = site.getConverterImpl(::Jekyll::Converters::Markdown)
       end
 
       html_output_for(response)


### PR DESCRIPTION
Was causing `Liquid Exception: undefined method 'find_converter_instance' for nil:NilClass in _includes/post/webmentions.html, included in _layouts/post.html` due to using `@site` where it should have been `site`.