### PR TITLE
Fix Deprecation: posts.each should be changed to posts.docs.each.

### DIFF
--- a/webmention_io.rb
+++ b/webmention_io.rb
@@ -404,7 +404,7 @@ module Jekyll
       webmentions = {}
       if defined?(WEBMENTION_CACHE_DIR)
         cache_file = File.join(WEBMENTION_CACHE_DIR, 'webmentions.yml')
-        site.posts.each do |post|
+        site.posts.docs.each do |post|
           source = "#{site.config['url']}#{post.url}"
           targets = []
           if post.data['in_reply_to']


### PR DESCRIPTION
Not sure if this should have a guard on it so it works for Jekyll 2.x and 3.x..? If so.. what should be added?