### PR TITLE
(deps) Bump uglifier to 4.x

### DIFF
--- a/jekyll-webmention_io.gemspec
+++ b/jekyll-webmention_io.gemspec
@@ -42,7 +42,7 @@ EOF
   s.add_runtime_dependency "openssl", "~> 2.0"
   s.add_runtime_dependency "string_inflection", "~> 0.1"
   s.add_runtime_dependency "htmlbeautifier", "~> 1.1"
-  s.add_runtime_dependency "uglifier", "~> 3.2"
+  s.add_runtime_dependency "uglifier", "~> 4.1"
   s.add_runtime_dependency "webmention", "~> 0.1.6"
 
   s.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
fix #78

This should prevent conflicts with `jekyll-assets`