### PR TITLE
set_data in tags with @template_name as type

### DIFF
--- a/lib/jekyll/tags/bookmarks.rb
+++ b/lib/jekyll/tags/bookmarks.rb
@@ -19,7 +19,7 @@ module Jekyll
       end
 
       def set_data(data, _types)
-        webmentions = extract_type "bookmarks", data
+        webmentions = extract_type @template_name, data
         @data = { "webmentions" => webmentions.values }
       end
     end

--- a/lib/jekyll/tags/likes.rb
+++ b/lib/jekyll/tags/likes.rb
@@ -19,7 +19,7 @@ module Jekyll
       end
 
       def set_data(data, _types)
-        webmentions = extract_type "likes", data
+        webmentions = extract_type @template_name, data
         @data = { "webmentions" => webmentions.values }
       end
     end

--- a/lib/jekyll/tags/links.rb
+++ b/lib/jekyll/tags/links.rb
@@ -19,7 +19,7 @@ module Jekyll
       end
 
       def set_data(data, _types)
-        webmentions = extract_type "links", data
+        webmentions = extract_type @template_name, data
         @data = { "webmentions" => webmentions.values }
       end
     end

--- a/lib/jekyll/tags/posts.rb
+++ b/lib/jekyll/tags/posts.rb
@@ -19,7 +19,7 @@ module Jekyll
       end
 
       def set_data(data, _types)
-        webmentions = extract_type "posts", data
+        webmentions = extract_type @template_name, data
         @data = { "webmentions" => webmentions.values }
       end
     end

--- a/lib/jekyll/tags/replies.rb
+++ b/lib/jekyll/tags/replies.rb
@@ -19,7 +19,7 @@ module Jekyll
       end
 
       def set_data(data, _types)
-        webmentions = extract_type "replies", data
+        webmentions = extract_type @template_name, data
         @data = { "webmentions" => webmentions.values }
       end
     end

--- a/lib/jekyll/tags/reposts.rb
+++ b/lib/jekyll/tags/reposts.rb
@@ -19,7 +19,7 @@ module Jekyll
       end
 
       def set_data(data, _types)
-        webmentions = extract_type "reposts", data
+        webmentions = extract_type @template_name, data
         @data = { "webmentions" => webmentions.values }
       end
     end

--- a/lib/jekyll/tags/rsvps.rb
+++ b/lib/jekyll/tags/rsvps.rb
@@ -19,7 +19,7 @@ module Jekyll
       end
 
       def set_data(data, _types)
-        webmentions = extract_type "rsvps", data
+        webmentions = extract_type @template_name, data
         @data = { "webmentions" => webmentions.values }
       end
     end


### PR DESCRIPTION
The tags in the diff here have `type` of `:set_data` referring to *the same "string"* passed to `self.temlate=` which internally sets the value of `@template_name`.

With this, `:set_data` of these tags have identical definition which can be refactored away in future..