### PR TITLE
Use shorter name for superclass

### DIFF
--- a/lib/jekyll/tags/bookmarks.rb
+++ b/lib/jekyll/tags/bookmarks.rb
@@ -11,7 +11,7 @@
 #
 module Jekyll
   module WebmentionIO
-    class WebmentionBookmarksTag < Jekyll::WebmentionIO::WebmentionTag
+    class WebmentionBookmarksTag < WebmentionTag
       def initialize(tag_name, text, tokens)
         super
         @text = text

--- a/lib/jekyll/tags/count.rb
+++ b/lib/jekyll/tags/count.rb
@@ -11,7 +11,7 @@
 #
 module Jekyll
   module WebmentionIO
-    class WebmentionCountTag < Jekyll::WebmentionIO::WebmentionTag
+    class WebmentionCountTag < WebmentionTag
       def initialize(tag_name, text, tokens)
         super
         @text = text

--- a/lib/jekyll/tags/likes.rb
+++ b/lib/jekyll/tags/likes.rb
@@ -11,7 +11,7 @@
 #
 module Jekyll
   module WebmentionIO
-    class WebmentionLikesTag < Jekyll::WebmentionIO::WebmentionTag
+    class WebmentionLikesTag < WebmentionTag
       def initialize(tag_name, text, tokens)
         super
         @text = text

--- a/lib/jekyll/tags/links.rb
+++ b/lib/jekyll/tags/links.rb
@@ -11,7 +11,7 @@
 #
 module Jekyll
   module WebmentionIO
-    class WebmentionLinksTag < Jekyll::WebmentionIO::WebmentionTag
+    class WebmentionLinksTag < WebmentionTag
       def initialize(tag_name, text, tokens)
         super
         @text = text

--- a/lib/jekyll/tags/posts.rb
+++ b/lib/jekyll/tags/posts.rb
@@ -11,7 +11,7 @@
 #
 module Jekyll
   module WebmentionIO
-    class WebmentionPostsTag < Jekyll::WebmentionIO::WebmentionTag
+    class WebmentionPostsTag < WebmentionTag
       def initialize(tag_name, text, tokens)
         super
         @text = text

--- a/lib/jekyll/tags/replies.rb
+++ b/lib/jekyll/tags/replies.rb
@@ -11,7 +11,7 @@
 #
 module Jekyll
   module WebmentionIO
-    class WebmentionRepliesTag < Jekyll::WebmentionIO::WebmentionTag
+    class WebmentionRepliesTag < WebmentionTag
       def initialize(tag_name, text, tokens)
         super
         @text = text

--- a/lib/jekyll/tags/reposts.rb
+++ b/lib/jekyll/tags/reposts.rb
@@ -11,7 +11,7 @@
 #
 module Jekyll
   module WebmentionIO
-    class WebmentionRepostsTag < Jekyll::WebmentionIO::WebmentionTag
+    class WebmentionRepostsTag < WebmentionTag
       def initialize(tag_name, text, tokens)
         super
         @text = text

--- a/lib/jekyll/tags/rsvps.rb
+++ b/lib/jekyll/tags/rsvps.rb
@@ -11,7 +11,7 @@
 #
 module Jekyll
   module WebmentionIO
-    class WebmentionRsvpsTag < Jekyll::WebmentionIO::WebmentionTag
+    class WebmentionRsvpsTag < WebmentionTag
       def initialize(tag_name, text, tokens)
         super
         @text = text

--- a/lib/jekyll/tags/webmentions.rb
+++ b/lib/jekyll/tags/webmentions.rb
@@ -11,7 +11,7 @@
 #
 module Jekyll
   module WebmentionIO
-    class WebmentionsTag < Jekyll::WebmentionIO::WebmentionTag
+    class WebmentionsTag < WebmentionTag
       def initialize(tag_name, text, tokens)
         super
         @text = text


### PR DESCRIPTION
This is purely for readability and in theory, should not affect the tag functionality.
If the longer version was originally used for performance reasons, you may close this.