### PR TITLE
Freeze string literals to improve performance

### DIFF
--- a/lib/jekyll/commands/webmention.rb
+++ b/lib/jekyll/commands/webmention.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require "json"
 

--- a/lib/jekyll/generators/compile_js.rb
+++ b/lib/jekyll/generators/compile_js.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/generators/compile_js.rb
+++ b/lib/jekyll/generators/compile_js.rb
@@ -45,7 +45,7 @@ module Jekyll
 
         @source_file_destination = (config["source"] == false ? Dir.mktmpdir : "#{@site.config["source"]}/#{config["destination"]}")
 
-        @javascript = ""
+        @javascript = +""
 
         concatenate_asset_files
 

--- a/lib/jekyll/generators/gather_webmentions.rb
+++ b/lib/jekyll/generators/gather_webmentions.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io
@@ -59,8 +59,6 @@ module Jekyll
                       @lookups[post.url]
                     elsif last_webmention
                       Date.parse last_webmention.dig("raw", "verified_date")
-                    else
-                      nil
                     end
 
       # should we throttle?

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/_.rb
+++ b/lib/jekyll/tags/_.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/bookmarks.rb
+++ b/lib/jekyll/tags/bookmarks.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/count.rb
+++ b/lib/jekyll/tags/count.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/likes.rb
+++ b/lib/jekyll/tags/likes.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/links.rb
+++ b/lib/jekyll/tags/links.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/posts.rb
+++ b/lib/jekyll/tags/posts.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/replies.rb
+++ b/lib/jekyll/tags/replies.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/reposts.rb
+++ b/lib/jekyll/tags/reposts.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/rsvps.rb
+++ b/lib/jekyll/tags/rsvps.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/webmentions.rb
+++ b/lib/jekyll/tags/webmentions.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/tags/webmentions_head.rb
+++ b/lib/jekyll/tags/webmentions_head.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io
@@ -11,7 +11,7 @@ module Jekyll
   module WebmentionIO
     class WebmentionHeadTag < Liquid::Tag
       def render(context)
-        head = ""
+        head = +""
         head << '<link rel="dns-prefetch" href="https://webmention.io">'
         head << '<link rel="preconnect" href="https://webmention.io">'
         head << '<link rel="preconnect" href="ws://webmention.io:8080">'

--- a/lib/jekyll/tags/webmentions_js.rb
+++ b/lib/jekyll/tags/webmentions_js.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io
@@ -27,14 +27,14 @@ module Jekyll
         config = config.merge(site_config)
 
         # JS file
-        js = ""
+        js = +""
         unless config["deploy"] == false
           js_file_path = "#{site.config["baseurl"]}/#{config["destination"]}/JekyllWebmentionIO.js"
           js << "<script src=\"#{js_file_path}\" async></script>"
         end
 
         Jekyll::WebmentionIO.log "info", "Gathering templates for JavaScript."
-        templates = ""
+        templates = +""
         template_files = Jekyll::WebmentionIO.types + %w(count webmentions)
         template_files.each do |template|
           templates << "<template style=\"display:none\" id=\"webmention-#{template}\">"

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io

--- a/lib/jekyll/webmention_io/version.rb
+++ b/lib/jekyll/webmention_io/version.rb
@@ -1,7 +1,7 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module Jekyll
   module WebmentionIO
-    VERSION = "2.9.6".freeze
+    VERSION = "2.9.6"
   end
 end

--- a/lib/jekyll/webmention_io/webmention.rb
+++ b/lib/jekyll/webmention_io/webmention.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 #  (c) Aaron Gustafson
 #  https://github.com/aarongustafson/jekyll-webmention_io


### PR DESCRIPTION
Making strings immutable helps improve performance by avoiding creating new string objects on each call