### PR TITLE
Add utility method to safely parse YAML files

### DIFF
--- a/lib/jekyll/commands/webmention.rb
+++ b/lib/jekyll/commands/webmention.rb
@@ -21,7 +21,7 @@ module Jekyll
         count = 0
         cached_outgoing = Jekyll::WebmentionIO.get_cache_file_path "outgoing"
         if File.exist?(cached_outgoing)
-          outgoing = open(cached_outgoing) { |f| YAML.load(f) }
+          outgoing = Jekyll::WebmentionIO.load_yaml(cached_outgoing)
           outgoing.each do |source, targets|
             targets.each do |target, response|
               next unless response == false

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -77,8 +77,8 @@ module Jekyll
       unless File.exist? old_sent_file
         return
       end
-      sent_webmentions = open(old_sent_file) { |f| YAML.load(f) }
-      outgoing_webmentions = open(old_outgoing_file) { |f| YAML.load(f) }
+      sent_webmentions = Jekyll::WebmentionIO.load_yaml(old_sent_file)
+      outgoing_webmentions = Jekyll::WebmentionIO.load_yaml(old_outgoing_file)
       merged = {}
       outgoing_webmentions.each do |source_url, webmentions|
         collection = {}

--- a/lib/jekyll/tags/_.rb
+++ b/lib/jekyll/tags/_.rb
@@ -17,7 +17,7 @@ module Jekyll
         super
         cache_file = Jekyll::WebmentionIO.get_cache_file_path "incoming"
         @cached_webmentions = if File.exist? cache_file
-                                open(cache_file) { |f| YAML.load(f) }
+                                Jekyll::WebmentionIO.load_yaml(cache_file)
                               else
                                 {}
                               end

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -84,9 +84,7 @@ module Jekyll
       end
 
       cache_file = get_cache_file_path which
-      cached_webmentions = open(cache_file) { |f| YAML.load(f) }
-
-      cached_webmentions
+      load_yaml(cache_file)
     end
 
     def self.cache_webmentions(which, webmentions)
@@ -140,8 +138,7 @@ module Jekyll
 
     def self.read_lookup_dates()
       cache_file = get_cache_file_path "lookups"
-      lookups = open(cache_file) { |f| YAML.load(f) }
-      lookups
+      load_yaml(cache_file)
     end
 
     def self.cache_lookup_dates(lookups)
@@ -286,6 +283,14 @@ module Jekyll
       File.open(file, "wb") { |f| f.puts YAML.dump(data) }
     end
 
+    # Utility Method
+    # Safely parse given YAML +file+ path and return data.
+    #
+    # Returns empty hash if parsing fails to return data
+    def self.load_yaml(file)
+      SafeYAML.load_file(file) || {}
+    end
+
     private
 
     def self.get_http_response(uri)
@@ -315,7 +320,7 @@ module Jekyll
       # Never cache webmention.io in here
       return if uri.host == "webmention.io"
       cache_file = @cache_files["bad_uris"]
-      bad_uris = open(cache_file) { |f| YAML.load(f) }
+      bad_uris = load_yaml(cache_file)
       bad_uris[uri.host] = Time.now.to_s
       dump_yaml(cache_file, bad_uris)
     end
@@ -323,7 +328,7 @@ module Jekyll
     def self.uri_ok?(uri)
       uri = URI.parse(URI.encode(uri))
       now = Time.now.to_s
-      bad_uris = open(@cache_files["bad_uris"]) { |f| YAML.load(f) }
+      bad_uris = load_yaml(@cache_files["bad_uris"])
       if bad_uris.key? uri.host
         last_checked = DateTime.parse(bad_uris[uri.host])
         cache_bad_uris_for = @config["cache_bad_uris_for"] || 1 # in days


### PR DESCRIPTION
Using `YAML.load` is a security concern when loading client-side YAML files because the contents are `eval`-ed before being loaded into memory and as such can be exploited..
Similar security concern arises when using `Kernel#open` to parse a file.