### PR TITLE
Improve handling cache folder and cache file paths

### DIFF
--- a/lib/jekyll-webmention_io.rb
+++ b/lib/jekyll-webmention_io.rb
@@ -3,4 +3,6 @@
 require "jekyll"
 require "jekyll/webmention_io"
 
-Jekyll::WebmentionIO.bootstrap
+Jekyll::Hooks.register :site, :after_init do |site|
+  Jekyll::WebmentionIO.bootstrap(site)
+end

--- a/lib/jekyll/commands/webmention.rb
+++ b/lib/jekyll/commands/webmention.rb
@@ -15,7 +15,7 @@ module Jekyll
       end
 
       def self.process(_args = [], _options = {})
-        if File.exist? "#{Jekyll::WebmentionIO.cache_folder}/#{Jekyll::WebmentionIO.file_prefix}sent.yml"
+        if File.exist? Jekyll::WebmentionIO.cache_file("sent.yml")
           Jekyll::WebmentionIO.log "error", "Your outgoing webmentions queue needs to be upgraded. Please re-build your project."
         end
         count = 0

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -72,8 +72,8 @@ module Jekyll
     end
 
     def upgrade_outgoing_webmention_cache
-      old_sent_file = "#{Jekyll::WebmentionIO.cache_folder}/#{Jekyll::WebmentionIO.file_prefix}sent.yml"
-      old_outgoing_file = "#{Jekyll::WebmentionIO.cache_folder}/#{Jekyll::WebmentionIO.file_prefix}queued.yml"
+      old_sent_file = Jekyll::WebmentionIO.cache_file("sent.yml")
+      old_outgoing_file = Jekyll::WebmentionIO.cache_file("queued.yml")
       unless File.exist? old_sent_file
         return
       end

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -41,21 +41,21 @@ module Jekyll
       OpenSSL::SSL::SSLError,
     ].freeze
 
-    def self.bootstrap
-      # @jekyll_config = Jekyll.configuration({ 'quiet' => true })
-      @jekyll_config = Jekyll.configuration({})
+    def self.bootstrap(site)
+      @site = site
+      @jekyll_config = site.config
       @config = @jekyll_config["webmentions"] || {}
 
       # Set up the cache folder & files
-      @cache_folder = @config["cache_folder"] || ".jekyll-cache"
+      @cache_folder = site.in_source_dir(@config["cache_folder"] || ".jekyll-cache")
       Dir.mkdir(@cache_folder) unless File.exist?(@cache_folder)
       @file_prefix = ""
       @file_prefix = "webmention_io_" unless @cache_folder.include? "webmention"
       @cache_files = {
-        "incoming" => "#{@cache_folder}/#{@file_prefix}received.yml",
-        "outgoing" => "#{@cache_folder}/#{@file_prefix}outgoing.yml",
-        "bad_uris" => "#{@cache_folder}/#{@file_prefix}bad_uris.yml",
-        "lookups"  => "#{@cache_folder}/#{@file_prefix}lookups.yml"
+        "incoming" => cache_file("received.yml"),
+        "outgoing" => cache_file("outgoing.yml"),
+        "bad_uris" => cache_file("bad_uris.yml"),
+        "lookups"  => cache_file("lookups.yml")
       }
       @cache_files.each_value do |file|
         unless File.exist?(file)
@@ -69,7 +69,11 @@ module Jekyll
       @api_endpoint = "#{@api_url}/#{path}"
     end
 
-    # Heplers
+    # Helpers
+    def self.cache_file(filename)
+      Jekyll.sanitized_path(@cache_folder, "#{@file_prefix}#{filename}")
+    end
+
     def self.get_cache_file_path(key)
       path = false
       if @cache_files.key? key


### PR DESCRIPTION
This is to ensure that the cache folder always resides under the site's `source` path.
A simple `File.join` leaves security holes for configs like following:
```yaml
webmentions:
  cache_folder: "../../.foo-cache"
```

An additional gain is a utility method `Jekyll::WebmentionIO.cache_file` to simplify creating `cache_file` paths.

However, **`Jekyll::WebmentionIO.bootstrap`** has now **changed its signature** to accept a required-parameter `site` (which is simply the current `Jekyll::Site` instance)