### PR TITLE
Render WebmentionJSTag with a dedicated class

### DIFF
--- a/lib/jekyll/generators/compile_js.rb
+++ b/lib/jekyll/generators/compile_js.rb
@@ -23,9 +23,9 @@ module Jekyll
       priority :low
 
       def generate(site)
-        @site = site
-        @file_name = "JekyllWebmentionIO.js"
         handler = Jekyll::WebmentionIO.js_handler
+        @site = site
+        @file_name = handler.resource_name
 
         if handler.disabled?
           Jekyll::WebmentionIO.log "info", "Skipping JavaScript inclusion."

--- a/lib/jekyll/tags/webmention.rb
+++ b/lib/jekyll/tags/webmention.rb
@@ -32,8 +32,9 @@ module Jekyll
       end
 
       def template=(template)
-        supported_templates = Jekyll::WebmentionIO.types + %w(count webmentions)
-        Jekyll::WebmentionIO.log "error", "#{template.capitalize} is not supported" unless supported_templates.include? template
+        unless Jekyll::WebmentionIO.supported_templates.include? template
+          Jekyll::WebmentionIO.log "error", "#{template.capitalize} is not supported"
+        end
         @template_name = template
         @template = Jekyll::WebmentionIO.get_template_contents(template)
         Jekyll::WebmentionIO.log "info", "#{template.capitalize} template:\n\n#{@template}\n\n"

--- a/lib/jekyll/tags/webmentions_js.rb
+++ b/lib/jekyll/tags/webmentions_js.rb
@@ -10,40 +10,8 @@
 module Jekyll
   module WebmentionIO
     class WebmentionJSTag < Liquid::Tag
-      def render(context)
-        site = context.registers[:site]
-
-        # JS can be turned off too
-        if site.config.dig("webmentions", "js") == false
-          Jekyll::WebmentionIO.log "info", "JavaScript output is disabled, so the {% webmentions_js %} tag is being skipped"
-          return ""
-        end
-
-        config = {
-          "destination" => "js",
-          "uglify"      => true,
-        }
-        site_config = site.config.dig("webmentions", "js") || {}
-        config = config.merge(site_config)
-
-        # JS file
-        js = +"" # unfrozen String
-        unless config["deploy"] == false
-          destination = config["destination"].chomp("/").reverse.chomp("/").reverse # removes prefix & suffix "/"
-          js_file_path = "#{site.config["baseurl"]}/#{destination}/JekyllWebmentionIO.js"
-          js << "<script src=\"#{js_file_path}\" async></script>"
-        end
-
-        Jekyll::WebmentionIO.log "info", "Gathering templates for JavaScript."
-        templates = +"" # unfrozen String
-        template_files = Jekyll::WebmentionIO.types + %w(count webmentions)
-        template_files.each do |template|
-          templates << "<template style=\"display:none\" id=\"webmention-#{template}\">"
-          templates << Jekyll::WebmentionIO.get_template_contents(template)
-          templates << "</template>"
-        end
-
-        "#{js}\n#{templates}"
+      def render(_context)
+        Jekyll::WebmentionIO.js_handler.render
       end
     end
   end

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -9,6 +9,7 @@
 #
 require_relative "webmention_io/version"
 require_relative "webmention_io/webmention"
+require_relative "webmention_io/js_handler"
 
 require "json"
 require "net/http"
@@ -22,7 +23,7 @@ module Jekyll
     class << self
       # define simple getters and setters
       attr_reader :config, :jekyll_config, :cache_files, :cache_folder,
-                  :file_prefix, :types
+                  :file_prefix, :types, :supported_templates, :js_handler
       attr_writer :api_suffix
     end
 
@@ -32,7 +33,11 @@ module Jekyll
     @api_endpoint = @api_url
     @api_suffix = ""
 
-    @types = %w(bookmarks likes links posts replies reposts rsvps)
+    @types = %w(bookmarks likes links posts replies reposts rsvps).freeze
+    @supported_templates = (@types + %w(count webmentions)).freeze
+
+    @template_file_cache = {}
+    @template_content_cache = {}
 
     EXCEPTIONS = [
       SocketError, Timeout::Error,
@@ -58,10 +63,10 @@ module Jekyll
         "lookups"  => cache_file("lookups.yml")
       }
       @cache_files.each_value do |file|
-        unless File.exist?(file)
-          dump_yaml(file)
-        end
+        dump_yaml(file) unless File.exist?(file)
       end
+
+      @js_handler = Jekyll::WebmentionIO::JSHandler.new(site)
     end
 
     # Setter
@@ -75,17 +80,11 @@ module Jekyll
     end
 
     def self.get_cache_file_path(key)
-      path = false
-      if @cache_files.key? key
-        path = @cache_files[key]
-      end
-      return path
+      @cache_files[key] || false
     end
 
     def self.read_cached_webmentions(which)
-      unless %w(incoming outgoing).include? which
-        return {}
-      end
+      return {} unless %w(incoming outgoing).include?(which)
 
       cache_file = get_cache_file_path which
       load_yaml(cache_file)
@@ -136,7 +135,7 @@ module Jekyll
       if source
         JSON.parse(source)
       else
-        ""
+        {}
       end
     end
 
@@ -235,15 +234,36 @@ module Jekyll
       end
     end
 
+    def self.template_file(template)
+      @template_file_cache[template] ||= begin
+        configured_template = @config.dig("templates", template)
+        if configured_template
+          log "info", "Using custom #{template} template"
+          configured_template
+        else
+          File.expand_path("templates/#{template}.html", __dir__)
+        end
+      end
+    end
+
     def self.get_template_contents(template)
-      template_file = if @config.dig("templates", template)
-                        log "info", "Using custom #{template} template"
-                        @config["templates"][template]
-                      else
-                        File.expand_path("templates/#{template}.html", __dir__)
-                      end
-      log "info", "Template file: #{template_file}"
-      File.read(template_file)
+      template_file = template_file(template)
+      @template_content_cache[template_file] ||= begin
+        log "info", "Template file: #{template_file}"
+        File.read(template_file)
+      end
+    end
+
+    def self.gathered_templates
+      @gathered_templates ||= begin
+        templates = +"" # unfrozen String
+        supported_templates.each do |template|
+          templates << "<template style=\"display:none\" id=\"webmention-#{template}\">"
+          templates << get_template_contents(template)
+          templates << "</template>"
+        end
+        templates
+      end
     end
 
     # Connections

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -254,8 +254,8 @@ module Jekyll
       end
     end
 
-    def self.gathered_templates
-      @gathered_templates ||= begin
+    def self.html_templates
+      @html_templates ||= begin
         templates = +"" # unfrozen String
         supported_templates.each do |template|
           templates << "<template style=\"display:none\" id=\"webmention-#{template}\">"

--- a/lib/jekyll/webmention_io/js_handler.rb
+++ b/lib/jekyll/webmention_io/js_handler.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#  (c) Aaron Gustafson
+#  https://github.com/aarongustafson/jekyll-webmention_io
+#  Licence : MIT
+#
+
+module Jekyll
+  module WebmentionIO
+    class JSHandler
+      attr_reader :destination, :resource_url
+
+      DEFAULTS = {
+        "destination" => "js",
+        "source"      => true,
+        "deploy"      => true,
+        "uglify"      => true,
+      }.freeze
+
+      def initialize(site)
+        js_config = site.config.dig("webmentions", "js")
+
+        @disabled = js_config == false
+
+        js_config = {} unless js_config.is_a?(Hash)
+        js_config = DEFAULTS.merge(js_config)
+
+        @deploy, @uglify, @source, @destination = js_config.values_at("deploy", "uglify", "source", "destination")
+        @resource_url = File.join(
+          "", site.config["baseurl"], @destination, "JekyllWebmentionIO.js"
+        )
+      end
+
+      def disabled?
+        @disabled == true
+      end
+
+      def deploy?
+        @deploy != false
+      end
+
+      def uglify?
+        @uglify != false
+      end
+
+      def source?
+        @source != false
+      end
+
+      def render
+        if disabled?
+          Jekyll::WebmentionIO.log "info",
+            "JavaScript output is disabled, so the {% webmentions_js %} tag is being skipped"
+          return ""
+        end
+
+        js_file = deploy? ? "<script src=\"#{resource_url}\" async></script>" : ""
+
+        Jekyll::WebmentionIO.log "info", "Gathering templates for JavaScript."
+        "#{js_file}\n#{Jekyll::WebmentionIO.gathered_templates}"
+      end
+    end
+  end
+end

--- a/lib/jekyll/webmention_io/js_handler.rb
+++ b/lib/jekyll/webmention_io/js_handler.rb
@@ -8,7 +8,7 @@
 module Jekyll
   module WebmentionIO
     class JSHandler
-      attr_reader :destination, :resource_url
+      attr_reader :destination, :resource_name, :resource_url
 
       DEFAULTS = {
         "destination" => "js",
@@ -26,8 +26,9 @@ module Jekyll
         js_config = DEFAULTS.merge(js_config)
 
         @deploy, @uglify, @source, @destination = js_config.values_at("deploy", "uglify", "source", "destination")
+        @resource_name = "JekyllWebmentionIO.js"
         @resource_url = File.join(
-          "", site.config["baseurl"], @destination, "JekyllWebmentionIO.js"
+          "", site.config["baseurl"], @destination, @resource_name
         )
       end
 
@@ -54,7 +55,7 @@ module Jekyll
           return ""
         end
 
-        js_file = deploy? ? "<script src=\"#{resource_url}\" async></script>" : ""
+        js_file = deploy? ? "<script src=\"#@resource_url\" async></script>" : ""
 
         Jekyll::WebmentionIO.log "info", "Gathering templates for JavaScript."
         "#{js_file}\n#{Jekyll::WebmentionIO.html_templates}"

--- a/lib/jekyll/webmention_io/js_handler.rb
+++ b/lib/jekyll/webmention_io/js_handler.rb
@@ -57,7 +57,7 @@ module Jekyll
         js_file = deploy? ? "<script src=\"#{resource_url}\" async></script>" : ""
 
         Jekyll::WebmentionIO.log "info", "Gathering templates for JavaScript."
-        "#{js_file}\n#{Jekyll::WebmentionIO.gathered_templates}"
+        "#{js_file}\n#{Jekyll::WebmentionIO.html_templates}"
       end
     end
   end


### PR DESCRIPTION
Resolves #99 

The rendered output of `WebmentionJSTag` is the same irrespective of given `context`. So the content can be rendered once, cached elsewhere and then retrieved from the cache for each call to the tag's `:render` method.

(This PR also involves a micro-optimization by caching array of supported_templates in the main module itself, to avoid unnecessary allocations)