### PR TITLE
Use shorter name for constants from plugin module

### DIFF
--- a/lib/jekyll/commands/webmention.rb
+++ b/lib/jekyll/commands/webmention.rb
@@ -15,22 +15,22 @@ module Jekyll
       end
 
       def self.process(_args = [], _options = {})
-        if File.exist? Jekyll::WebmentionIO.cache_file("sent.yml")
-          Jekyll::WebmentionIO.log "error", "Your outgoing webmentions queue needs to be upgraded. Please re-build your project."
+        if File.exist? WebmentionIO.cache_file("sent.yml")
+          WebmentionIO.log "error", "Your outgoing webmentions queue needs to be upgraded. Please re-build your project."
         end
         count = 0
-        cached_outgoing = Jekyll::WebmentionIO.get_cache_file_path "outgoing"
+        cached_outgoing = WebmentionIO.get_cache_file_path "outgoing"
         if File.exist?(cached_outgoing)
-          outgoing = Jekyll::WebmentionIO.load_yaml(cached_outgoing)
+          outgoing = WebmentionIO.load_yaml(cached_outgoing)
           outgoing.each do |source, targets|
             targets.each do |target, response|
               next unless response == false
               if target.index("//").zero?
                 target = "http:#{target}"
               end
-              endpoint = Jekyll::WebmentionIO.get_webmention_endpoint(target)
+              endpoint = WebmentionIO.get_webmention_endpoint(target)
               next unless endpoint
-              response = Jekyll::WebmentionIO.webmention(source, target, endpoint)
+              response = WebmentionIO.webmention(source, target, endpoint)
               next unless response
               begin
                 response = JSON.parse response
@@ -42,9 +42,9 @@ module Jekyll
             end
           end
           if count.positive?
-            Jekyll::WebmentionIO.dump_yaml(cached_outgoing, outgoing)
+            WebmentionIO.dump_yaml(cached_outgoing, outgoing)
           end
-          Jekyll::WebmentionIO.log "msg", "#{count} webmentions sent."
+          WebmentionIO.log "msg", "#{count} webmentions sent."
         end # file exists (outgoing)
       end # def process
     end # WebmentionCommand

--- a/lib/jekyll/generators/compile_js.rb
+++ b/lib/jekyll/generators/compile_js.rb
@@ -13,7 +13,7 @@ module Jekyll
   module WebmentionIO
     class JavaScriptFile < StaticFile
       def destination_rel_dir
-        Jekyll::WebmentionIO.js_handler.destination
+        WebmentionIO.js_handler.destination
       end
     end
 
@@ -23,12 +23,12 @@ module Jekyll
       priority :low
 
       def generate(site)
-        handler = Jekyll::WebmentionIO.js_handler
+        handler = WebmentionIO.js_handler
         @site = site
         @file_name = handler.resource_name
 
         if handler.disabled?
-          Jekyll::WebmentionIO.log "info", "Skipping JavaScript inclusion."
+          WebmentionIO.log "info", "Skipping JavaScript inclusion."
           return
         end
 
@@ -52,7 +52,7 @@ module Jekyll
 
       def add_webmention_types
         js_types = []
-        Jekyll::WebmentionIO.types.each do |type|
+        WebmentionIO.types.each do |type|
           js_types.push "'#{type}': '#{type.to_singular}'"
         end
         types_js = <<-EOF
@@ -82,7 +82,7 @@ module Jekyll
       end
 
       def deploy_js_file
-        js_file = Jekyll::WebmentionIO::JavaScriptFile.new(@site, @source_file_destination, "", @file_name)
+        js_file = WebmentionIO::JavaScriptFile.new(@site, @source_file_destination, "", @file_name)
         @site.static_files << js_file
       end
     end

--- a/lib/jekyll/generators/gather_webmentions.rb
+++ b/lib/jekyll/generators/gather_webmentions.rb
@@ -18,39 +18,39 @@ module Jekyll
       @site = site
       
       if @site.config["url"].to_s.include? "localhost"
-        Jekyll::WebmentionIO.log "msg", "Webmentions won’t be gathered on localhost."
+        WebmentionIO.log "msg", "Webmentions won’t be gathered on localhost."
         return
       end
 
       if @site.config.dig("webmentions", "pause_lookups") == true
-        Jekyll::WebmentionIO.log "msg", "Webmention gathering is currently paused."
+        WebmentionIO.log "msg", "Webmention gathering is currently paused."
         return
       end
 
-      Jekyll::WebmentionIO.log "msg", "Beginning to gather webmentions of your posts. This may take a while."
+      WebmentionIO.log "msg", "Beginning to gather webmentions of your posts. This may take a while."
 
-      Jekyll::WebmentionIO.api_path = "mentions"
+      WebmentionIO.api_path = "mentions"
       # add an arbitrarily high perPage to trump pagination
-      Jekyll::WebmentionIO.api_suffix = "&perPage=9999"
+      WebmentionIO.api_suffix = "&perPage=9999"
 
-      @cached_webmentions = Jekyll::WebmentionIO.read_cached_webmentions "incoming"
+      @cached_webmentions = WebmentionIO.read_cached_webmentions "incoming"
 
-      @lookups = Jekyll::WebmentionIO.read_lookup_dates
+      @lookups = WebmentionIO.read_lookup_dates
 
-      posts = Jekyll::WebmentionIO.gather_documents(@site)
+      posts = WebmentionIO.gather_documents(@site)
       posts.each do |post|
         check_for_webmentions(post)
       end
 
-      Jekyll::WebmentionIO.cache_lookup_dates @lookups
+      WebmentionIO.cache_lookup_dates @lookups
 
-      Jekyll::WebmentionIO.cache_webmentions "incoming", @cached_webmentions
+      WebmentionIO.cache_webmentions "incoming", @cached_webmentions
     end # generate
 
     private
 
     def check_for_webmentions(post)
-      Jekyll::WebmentionIO.log "info", "Checking for webmentions of #{post.url}."
+      WebmentionIO.log "info", "Checking for webmentions of #{post.url}."
 
       last_webmention = @cached_webmentions.dig(post.url, @cached_webmentions.dig(post.url)&.keys&.last)
 
@@ -63,8 +63,8 @@ module Jekyll
 
       # should we throttle?
       if post.respond_to? "date" # Some docs have no date
-        if last_lookup && Jekyll::WebmentionIO.post_should_be_throttled?(post, post.date, last_lookup)
-          Jekyll::WebmentionIO.log "info", "Throttling this post."
+        if last_lookup && WebmentionIO.post_should_be_throttled?(post, post.date, last_lookup)
+          WebmentionIO.log "info", "Throttling this post."
           return
         end
       end
@@ -76,12 +76,12 @@ module Jekyll
       targets = get_webmention_target_urls(post)
 
       # execute the API
-      response = Jekyll::WebmentionIO.get_response assemble_api_params(targets, since_id)
+      response = WebmentionIO.get_response assemble_api_params(targets, since_id)
       webmentions = response.dig("links")
       if webmentions && !webmentions.empty?
-        Jekyll::WebmentionIO.log "info", "Here’s what we got back:\n\n#{response.inspect}\n\n"
+        WebmentionIO.log "info", "Here’s what we got back:\n\n#{response.inspect}\n\n"
       else
-        Jekyll::WebmentionIO.log "info", "No webmentions found."
+        WebmentionIO.log "info", "No webmentions found."
       end
 
       @lookups[post.url] = Date.today
@@ -119,11 +119,11 @@ module Jekyll
     end
 
     def gather_legacy_targets(uri, targets)
-      if Jekyll::WebmentionIO.config.key? "legacy_domains"
-        Jekyll::WebmentionIO.log "info", "adding legacy URIs"
-        Jekyll::WebmentionIO.config["legacy_domains"].each do |domain|
+      if WebmentionIO.config.key? "legacy_domains"
+        WebmentionIO.log "info", "adding legacy URIs"
+        WebmentionIO.config["legacy_domains"].each do |domain|
           legacy = uri.sub @site.config["url"], domain
-          Jekyll::WebmentionIO.log "info", "adding URI #{legacy}"
+          WebmentionIO.log "info", "adding URI #{legacy}"
           targets.push(legacy)
         end
       end
@@ -146,7 +146,7 @@ module Jekyll
 
       if response && response["links"]
         response["links"].reverse_each do |link|
-          webmention = Jekyll::WebmentionIO::Webmention.new(link, @site)
+          webmention = WebmentionIO::Webmention.new(link, @site)
 
           # Do we already have it?
           if webmentions.key? webmention.id
@@ -154,7 +154,7 @@ module Jekyll
           end
 
           # Add it to the list
-          Jekyll::WebmentionIO.log "info", webmention.to_hash.inspect
+          WebmentionIO.log "info", webmention.to_hash.inspect
           webmentions[webmention.id] = webmention.to_hash
         end # each link
       end # if response

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -16,20 +16,20 @@ module Jekyll
       @site = site
 
       if @site.config["url"].to_s.include? "localhost"
-        Jekyll::WebmentionIO.log "msg", "Webmentions lookups are not run on localhost."
+        WebmentionIO.log "msg", "Webmentions lookups are not run on localhost."
         return
       end
       
       if @site.config.dig("webmentions", "pause_lookups")
-        Jekyll::WebmentionIO.log "info", "Webmention lookups are currently paused."
+        WebmentionIO.log "info", "Webmention lookups are currently paused."
         return
       end
 
-      Jekyll::WebmentionIO.log "msg", "Beginning to gather webmentions you’ve made. This may take a while."
+      WebmentionIO.log "msg", "Beginning to gather webmentions you’ve made. This may take a while."
 
       upgrade_outgoing_webmention_cache
 
-      posts = Jekyll::WebmentionIO.gather_documents(@site)
+      posts = WebmentionIO.gather_documents(@site)
 
       gather_webmentions(posts)
     end
@@ -37,7 +37,7 @@ module Jekyll
     private
 
     def gather_webmentions(posts)
-      webmentions = Jekyll::WebmentionIO.read_cached_webmentions "outgoing"
+      webmentions = WebmentionIO.read_cached_webmentions "outgoing"
 
       base_uri = @site.config["url"].to_s.chomp("/")
 
@@ -55,7 +55,7 @@ module Jekyll
         end
       end
 
-      Jekyll::WebmentionIO.cache_webmentions "outgoing", webmentions
+      WebmentionIO.cache_webmentions "outgoing", webmentions
     end
 
     def get_mentioned_uris(post)
@@ -72,13 +72,13 @@ module Jekyll
     end
 
     def upgrade_outgoing_webmention_cache
-      old_sent_file = Jekyll::WebmentionIO.cache_file("sent.yml")
-      old_outgoing_file = Jekyll::WebmentionIO.cache_file("queued.yml")
+      old_sent_file = WebmentionIO.cache_file("sent.yml")
+      old_outgoing_file = WebmentionIO.cache_file("queued.yml")
       unless File.exist? old_sent_file
         return
       end
-      sent_webmentions = Jekyll::WebmentionIO.load_yaml(old_sent_file)
-      outgoing_webmentions = Jekyll::WebmentionIO.load_yaml(old_outgoing_file)
+      sent_webmentions = WebmentionIO.load_yaml(old_sent_file)
+      outgoing_webmentions = WebmentionIO.load_yaml(old_outgoing_file)
       merged = {}
       outgoing_webmentions.each do |source_url, webmentions|
         collection = {}
@@ -91,9 +91,9 @@ module Jekyll
         end
         merged[source_url] = collection
       end
-      Jekyll::WebmentionIO.cache_webmentions "outgoing", merged
+      WebmentionIO.cache_webmentions "outgoing", merged
       File.delete old_sent_file, old_outgoing_file
-      Jekyll::WebmentionIO.log "msg", "Upgraded your sent webmentions cache."
+      WebmentionIO.log "msg", "Upgraded your sent webmentions cache."
     end
   end
 end

--- a/lib/jekyll/tags/webmention.rb
+++ b/lib/jekyll/tags/webmention.rb
@@ -15,9 +15,9 @@ module Jekyll
     class WebmentionTag < Liquid::Tag
       def initialize(tag_name, text, tokens)
         super
-        cache_file = Jekyll::WebmentionIO.get_cache_file_path "incoming"
+        cache_file = WebmentionIO.get_cache_file_path "incoming"
         @cached_webmentions = if File.exist? cache_file
-                                Jekyll::WebmentionIO.load_yaml(cache_file)
+                                WebmentionIO.load_yaml(cache_file)
                               else
                                 {}
                               end
@@ -32,12 +32,12 @@ module Jekyll
       end
 
       def template=(template)
-        unless Jekyll::WebmentionIO.supported_templates.include? template
-          Jekyll::WebmentionIO.log "error", "#{template.capitalize} is not supported"
+        unless WebmentionIO.supported_templates.include? template
+          WebmentionIO.log "error", "#{template.capitalize} is not supported"
         end
         @template_name = template
-        @template = Jekyll::WebmentionIO.get_template_contents(template)
-        Jekyll::WebmentionIO.log "info", "#{template.capitalize} template:\n\n#{@template}\n\n"
+        @template = WebmentionIO.get_template_contents(template)
+        WebmentionIO.log "info", "#{template.capitalize} template:\n\n#{@template}\n\n"
       end
 
       def set_data(data, types)
@@ -45,13 +45,13 @@ module Jekyll
       end
 
       def extract_type(type, webmentions)
-        Jekyll::WebmentionIO.log "info", "Looking for #{type}"
+        WebmentionIO.log "info", "Looking for #{type}"
         keep = {}
-        if !Jekyll::WebmentionIO.types.include? type
-          Jekyll::WebmentionIO.log "warn", "#{type} are not extractable"
+        if !WebmentionIO.types.include? type
+          WebmentionIO.log "warn", "#{type} are not extractable"
         else
           type = type.to_singular
-          Jekyll::WebmentionIO.log "info", "Searching #{webmentions.length} webmentions for type==#{type}"
+          WebmentionIO.log "info", "Searching #{webmentions.length} webmentions for type==#{type}"
           if webmentions.is_a? Hash
             webmentions = webmentions.values
           end
@@ -73,19 +73,19 @@ module Jekyll
 
         if @cached_webmentions.key? uri
           all_webmentions = @cached_webmentions[uri].clone
-          Jekyll::WebmentionIO.log "info", "#{all_webmentions.length} total webmentions for #{uri}"
+          WebmentionIO.log "info", "#{all_webmentions.length} total webmentions for #{uri}"
 
           if args.length.positive?
-            Jekyll::WebmentionIO.log "info", "Requesting only #{args.inspect}"
+            WebmentionIO.log "info", "Requesting only #{args.inspect}"
             webmentions = {}
             args.each do |type|
               types.push type
               extracted = extract_type(type, all_webmentions)
-              Jekyll::WebmentionIO.log "info", "Merging in #{extracted.length} #{type}"
+              WebmentionIO.log "info", "Merging in #{extracted.length} #{type}"
               webmentions = webmentions.merge(extracted)
             end
           else
-            Jekyll::WebmentionIO.log "info", "Grabbing all webmentions"
+            WebmentionIO.log "info", "Grabbing all webmentions"
             webmentions = all_webmentions
           end
 
@@ -104,20 +104,20 @@ module Jekyll
 
       def render_into_template(context_registry)
         if @template && @data
-          Jekyll::WebmentionIO.log "info", "Preparing to render webmention info into the #{@template_name} template."
+          WebmentionIO.log "info", "Preparing to render webmention info into the #{@template_name} template."
           template = Liquid::Template.parse(@template, :error_mode => :strict)
           html = template.render!(@data, :registers => context_registry, :strict_variables => false, :strict_filters => true)
           template.errors.each do |error|
-            Jekyll::WebmentionIO.log "error", error
+            WebmentionIO.log "error", error
           end
           # Clean up the output
           HtmlBeautifier.beautify html.each_line.reject { |x| x.strip == "" }.join
         else
           unless @template
-            Jekyll::WebmentionIO.log "warn", "#{self.class} No template provided"
+            WebmentionIO.log "warn", "#{self.class} No template provided"
           end
           unless @data
-            Jekyll::WebmentionIO.log "warn", "#{self.class} No data provided"
+            WebmentionIO.log "warn", "#{self.class} No data provided"
           end
           ""
         end

--- a/lib/jekyll/tags/webmentions_js.rb
+++ b/lib/jekyll/tags/webmentions_js.rb
@@ -11,7 +11,7 @@ module Jekyll
   module WebmentionIO
     class WebmentionJSTag < Liquid::Tag
       def render(_context)
-        Jekyll::WebmentionIO.js_handler.render
+        WebmentionIO.js_handler.render
       end
     end
   end

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -66,7 +66,7 @@ module Jekyll
         dump_yaml(file) unless File.exist?(file)
       end
 
-      @js_handler = Jekyll::WebmentionIO::JSHandler.new(site)
+      @js_handler = WebmentionIO::JSHandler.new(site)
     end
 
     # Setter

--- a/lib/jekyll/webmention_io/js_handler.rb
+++ b/lib/jekyll/webmention_io/js_handler.rb
@@ -50,15 +50,15 @@ module Jekyll
 
       def render
         if disabled?
-          Jekyll::WebmentionIO.log "info",
+          WebmentionIO.log "info",
             "JavaScript output is disabled, so the {% webmentions_js %} tag is being skipped"
           return ""
         end
 
         js_file = deploy? ? "<script src=\"#@resource_url\" async></script>" : ""
 
-        Jekyll::WebmentionIO.log "info", "Gathering templates for JavaScript."
-        "#{js_file}\n#{Jekyll::WebmentionIO.html_templates}"
+        WebmentionIO.log "info", "Gathering templates for JavaScript."
+        "#{js_file}\n#{WebmentionIO.html_templates}"
       end
     end
   end

--- a/lib/jekyll/webmention_io/webmention.rb
+++ b/lib/jekyll/webmention_io/webmention.rb
@@ -53,9 +53,9 @@ module Jekyll
       def markdownify(string)
         unless @converter
           @converter = if defined? @site.find_converter_instance
-                         @site.find_converter_instance(::Jekyll::Converters::Markdown)
+                         @site.find_converter_instance(Jekyll::Converters::Markdown)
                        else
-                         @site.getConverterImpl(::Jekyll::Converters::Markdown)
+                         @site.getConverterImpl(Jekyll::Converters::Markdown)
                        end
         end
 
@@ -134,7 +134,7 @@ module Jekyll
 
         if @type == "post"
 
-          html_source = Jekyll::WebmentionIO.get_uri_source(@uri)
+          html_source = WebmentionIO.get_uri_source(@uri)
           unless html_source
             return title
           end


### PR DESCRIPTION
Since the constants are nested under `module Jekyll`, Ruby will resolve them without errors

(Leaving constants from Jekyll Core and plugin constants nested under `module WebmentioIO` as is for readability, even though those constants will resolve equally fine as well..)