### PR TITLE
Stringify config["url"] and config["baseurl"]

### DIFF
--- a/lib/jekyll/generators/gather_webmentions.rb
+++ b/lib/jekyll/generators/gather_webmentions.rb
@@ -16,8 +16,9 @@ module Jekyll
 
     def generate(site)
       @site = site
+      @site_url = site.config["url"].to_s
       
-      if @site.config["url"].to_s.include? "localhost"
+      if @site_url.include? "localhost"
         Jekyll::WebmentionIO.log "msg", "Webmentions won’t be gathered on localhost."
         return
       end
@@ -90,8 +91,7 @@ module Jekyll
 
     def get_webmention_target_urls(post)
       targets = []
-      base_uri = @site.config["url"].chomp("/")
-      uri = "#{base_uri}#{post.url}"
+      uri = File.join(@site_url, post.url)
       targets.push(uri)
 
       # Redirection?
@@ -122,7 +122,7 @@ module Jekyll
       if Jekyll::WebmentionIO.config.key? "legacy_domains"
         Jekyll::WebmentionIO.log "info", "adding legacy URIs"
         Jekyll::WebmentionIO.config["legacy_domains"].each do |domain|
-          legacy = uri.sub @site.config["url"], domain
+          legacy = uri.sub(@site_url, domain)
           Jekyll::WebmentionIO.log "info", "adding URI #{legacy}"
           targets.push(legacy)
         end

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -14,8 +14,9 @@ module Jekyll
 
     def generate(site)
       @site = site
+      @site_url = site.config["url"].to_s
 
-      if @site.config["url"].to_s.include? "localhost"
+      if @site_url.include? "localhost"
         Jekyll::WebmentionIO.log "msg", "Webmentions lookups are not run on localhost."
         return
       end
@@ -39,10 +40,8 @@ module Jekyll
     def gather_webmentions(posts)
       webmentions = Jekyll::WebmentionIO.read_cached_webmentions "outgoing"
 
-      base_uri = @site.config["url"].to_s.chomp("/")
-
       posts.each do |post|
-        uri = "#{base_uri}#{post.url}"
+        uri = File.join(@site_url, post.url)
         mentions = get_mentioned_uris(post)
         if webmentions.key? uri
           mentions.each do |mentioned_uri, response|

--- a/lib/jekyll/tags/webmentions_head.rb
+++ b/lib/jekyll/tags/webmentions_head.rb
@@ -18,11 +18,12 @@ module Jekyll
 
         page = context["page"]
         site = context.registers[:site]
+        site_url = site.config["url"].to_s
         if page["redirect_from"]
           if page["redirect_from"].is_a? String
-            redirect = site.config["url"] + page["redirect_from"]
+            redirect = site_url + page["redirect_from"]
           elsif page["redirect_from"].is_a? Array
-            redirect = site.config["url"] + page["redirect_from"].join(",#{site.config["url"]}")
+            redirect = site_url + page["redirect_from"].join(",#{site_url}")
           end
           head << "<meta property=\"webmention:redirected_from\" content=\"#{redirect}\">"
         end

--- a/lib/jekyll/webmention_io/js_handler.rb
+++ b/lib/jekyll/webmention_io/js_handler.rb
@@ -28,7 +28,7 @@ module Jekyll
         @deploy, @uglify, @source, @destination = js_config.values_at("deploy", "uglify", "source", "destination")
         @resource_name = "JekyllWebmentionIO.js"
         @resource_url = File.join(
-          "", site.config["baseurl"], @destination, @resource_name
+          "", site.config["baseurl"].to_s, @destination, @resource_name
         )
       end
 


### PR DESCRIPTION
Because `site.config["url"]` and `site.config["baseurl"]` are `nil` by default