### PR TITLE
Drop support for outdated Jekyll versions

### DIFF
--- a/jekyll-webmention_io.gemspec
+++ b/jekyll-webmention_io.gemspec
@@ -36,7 +36,7 @@ EOF
   s.files         = `git ls-files app lib`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "jekyll", ">= 2.0", "< 4.0"
+  s.add_runtime_dependency "jekyll", ">= 3.2.0", "< 4.0"
   s.add_runtime_dependency "json", "~> 2.0"
   s.add_runtime_dependency "http", "~> 2.0"
   s.add_runtime_dependency "openssl", "~> 2.0"

--- a/lib/jekyll/commands/webmention.rb
+++ b/lib/jekyll/commands/webmention.rb
@@ -25,13 +25,16 @@ module Jekyll
           outgoing.each do |source, targets|
             targets.each do |target, response|
               next unless response == false
+
               if target.index("//").zero?
                 target = "http:#{target}"
               end
               endpoint = WebmentionIO.get_webmention_endpoint(target)
               next unless endpoint
+
               response = WebmentionIO.webmention(source, target, endpoint)
               next unless response
+
               begin
                 response = JSON.parse response
               rescue JSON::ParserError

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -101,11 +101,7 @@ module Jekyll
     end
 
     def self.gather_documents(site)
-      documents = if Jekyll::VERSION >= "3.0.0"
-                    site.posts.docs.clone
-                  else
-                    site.posts.clone
-                  end
+      documents = site.posts.docs.clone
 
       if @config.dig("pages") == true
         log "info", "Including site pages."
@@ -140,7 +136,7 @@ module Jekyll
       end
     end
 
-    def self.read_lookup_dates()
+    def self.read_lookup_dates
       cache_file = get_cache_file_path "lookups"
       load_yaml(cache_file)
     end
@@ -181,7 +177,7 @@ module Jekyll
           break
         end
       end
-      timeframe = "older" unless timeframe
+      timeframe ||= "older"
       return timeframe
     end
 
@@ -214,7 +210,7 @@ module Jekyll
       begin
         endpoint = Webmention::Client.supports_webmention?(uri)
         log("info", "Could not find a webmention endpoint at #{uri}") unless endpoint
-      rescue => e
+      rescue StandardError => e
         log "info", "Endpoint lookup failed for #{uri}: #{e.message}"
         endpoint = false
       end
@@ -347,6 +343,7 @@ module Jekyll
     def self.uri_is_not_ok(uri)
       # Never cache webmention.io in here
       return if uri.host == "webmention.io"
+
       cache_file = @cache_files["bad_uris"]
       bad_uris = load_yaml(cache_file)
       bad_uris[uri.host] = Time.now.to_s

--- a/lib/jekyll/webmention_io/webmention.rb
+++ b/lib/jekyll/webmention_io/webmention.rb
@@ -51,13 +51,7 @@ module Jekyll
       end
 
       def markdownify(string)
-        unless @converter
-          @converter = if defined? @site.find_converter_instance
-                         @site.find_converter_instance(Jekyll::Converters::Markdown)
-                       else
-                         @site.getConverterImpl(Jekyll::Converters::Markdown)
-                       end
-        end
+        @converter ||= @site.find_converter_instance(Jekyll::Converters::Markdown)
 
         if string
           string = @converter.convert(string.to_s)


### PR DESCRIPTION
`after_init` hook was added in [Jekyll 3.2.0](https://github.com/jekyll/jekyll/blob/master/History.markdown#320--2016-07-26)