### PR TITLE
Remove unused dependency

### DIFF
--- a/jekyll-webmention_io.gemspec
+++ b/jekyll-webmention_io.gemspec
@@ -38,7 +38,6 @@ EOF
 
   s.add_runtime_dependency "jekyll", ">= 2.0", "< 4.0"
   s.add_runtime_dependency "json", "~> 2.0"
-  s.add_runtime_dependency "http", "~> 2.0"
   s.add_runtime_dependency "openssl", "~> 2.0"
   s.add_runtime_dependency "string_inflection", "~> 0.1"
   s.add_runtime_dependency "htmlbeautifier", "~> 1.1"


### PR DESCRIPTION
`HTTP` from the `gem 'http'` module doesn't seem to be used anywhere..