### PR TITLE
Bootstrap WebmentionIO with webmention command

### DIFF
--- a/lib/jekyll/commands/webmention.rb
+++ b/lib/jekyll/commands/webmention.rb
@@ -14,7 +14,10 @@ module Jekyll
         end
       end
 
-      def self.process(_args = [], _options = {})
+      def self.process(_args = [], options = {})
+        options = configuration_from_options(options)
+        WebmentionIO.bootstrap(Jekyll::Site.new(options))
+
         if File.exist? WebmentionIO.cache_file("sent.yml")
           WebmentionIO.log "error", "Your outgoing webmentions queue needs to be upgraded. Please re-build your project."
         end


### PR DESCRIPTION
Since `jekyll webmention` command is going to be used separately from `jekyll build` or `jekyll serve`, we can initialize a new `Jekyll::Site` instance for the plugin's command.

Resolves #115 

P.S. @aarongustafson if you can "describe" how a sample site would look when this command is to be used, we can setup Travis to test this class as well..