### PR TITLE
Don't allow unsafe characters in URLs

### DIFF
--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 #  (c) Aaron Gustafson
@@ -69,7 +70,7 @@ module Jekyll
         if post.data["in_reply_to"]
           uris[post.data["in_reply_to"]] = false
         end
-        post.content.scan(/(?:https?:)?\/\/[^\s)#"]+/) do |match|
+        post.content.scan(/(?:https?:)?\/\/[^\s)#\[\]{}<>%|\^"]+/) do |match|
           unless uris.key? match
             uris[match] = false
           end


### PR DESCRIPTION
Why:

 * asciidoc files has links like http://example.com[Example] which
   currently when parsed includes the [Example] section
 * This causes errors when parsing the url later on.

This change addreses the need by:

 * Add unsafe characters to the exclusin in the regular expression match
   See https://perishablepress.com/stop-using-unsafe-characters-in-urls/

Fixes #120 