### PR TITLE
Don't classify all posts as 'older'

### DIFF
--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -171,6 +171,7 @@ module Jekyll
 
     def self.get_timeframe_from_date(time)
       date = time.to_date
+      timeframe = nil
       TIMEFRAMES.each do |key, value|
         if date.to_date > get_date_from_string(value)
           timeframe = key


### PR DESCRIPTION
Why:

 * the calculation of age posts was always `older` no matter
   the date.

This change addreses the need by:

 * init timeframe variable so it will actually be properly visible
   to make calculations right.