### PR TITLE
fix uri detection

### DIFF
--- a/lib/jekyll/commands/webmention.rb
+++ b/lib/jekyll/commands/webmention.rb
@@ -38,7 +38,7 @@ module Jekyll
                 next unless response == false
 
                 # convert protocol-less links
-                if target.index("//").zero?
+                if target.index("//") && target.index("//").zero?
                   target = "http:#{target}"
                 end
 

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -80,6 +80,11 @@ module Jekyll
             uris[syndicate] = false
           end
         end
+        if post.data["mf-mp-syndicate-to"]
+          for syndicate in post.data["mf-mp-syndicate-to"]
+            uris[syndicate] = false
+          end
+        end
         return uris
       end
 

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -75,6 +75,11 @@ module Jekyll
             uris[match] = false
           end
         end
+        if post.data["mf-syndicate-to"]
+          for syndicate in post.data["mf-syndicate-to"]
+            uris[syndicate] = false
+          end
+        end
         return uris
       end
 

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -75,36 +75,17 @@ module Jekyll
             uris[match] = false
           end
         end
-        if post.data["mf-syndicate-to"]
-          for syndicate in post.data["mf-syndicate-to"]
-            uris[syndicate] = false
+
+        %w(mf mf-mp).each do |prefix|
+          %w(syndicate-to repost-of like-of in-reply-to bookmark-of).each do |kind|
+            if syndicates = post.data["#{prefix}-#{kind}"]
+              for syndicate in syndicates
+                uris[syndicate] = false
+              end
+            end            
           end
         end
-        if post.data["mf-mp-syndicate-to"]
-          for syndicate in post.data["mf-mp-syndicate-to"]
-            uris[syndicate] = false
-          end
-        end
-        if post.data["mf-repost-of"]
-          for syndicate in post.data["mp-repost-of"]
-            uris[syndicate] = false
-          end
-        end
-        if post.data["mf-like-of"]
-          for syndicate in post.data["mp-like-of"]
-            uris[syndicate] = false
-          end
-        end
-        if post.data["mf-in-reply-to"]
-          for syndicate in post.data["mf-in-reply-to"]
-            uris[syndicate] = false
-          end
-        end
-        if post.data["mf-bookmark-of"]
-          for syndicate in post.data["mf-bookmark-of"]
-            uris[syndicate] = false
-          end
-        end
+
         return uris
       end
 

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -80,6 +80,7 @@ module Jekyll
           %w(syndicate-to repost-of like-of in-reply-to bookmark-of).each do |kind|
             if syndicates = post.data["#{prefix}-#{kind}"]
               for syndicate in syndicates
+                WebmentionIO.log "info", "Syndicate #{syndicate}."
                 uris[syndicate] = false
               end
             end            

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -85,6 +85,26 @@ module Jekyll
             uris[syndicate] = false
           end
         end
+        if post.data["mf-repost-of"]
+          for syndicate in post.data["mp-repost-of"]
+            uris[syndicate] = false
+          end
+        end
+        if post.data["mf-like-of"]
+          for syndicate in post.data["mp-like-of"]
+            uris[syndicate] = false
+          end
+        end
+        if post.data["mf-in-reply-to"]
+          for syndicate in post.data["mf-in-reply-to"]
+            uris[syndicate] = false
+          end
+        end
+        if post.data["mf-bookmark-of"]
+          for syndicate in post.data["mf-bookmark-of"]
+            uris[syndicate] = false
+          end
+        end
         return uris
       end
 

--- a/lib/jekyll/tags/webmention.rb
+++ b/lib/jekyll/tags/webmention.rb
@@ -65,9 +65,8 @@ module Jekyll
       def render(context)
         # Get the URI
         args = @text.split(/\s+/).map(&:strip)
-        uri = args.shift
-        uri = lookup(context, uri)
-
+        uri = context['page']['permalink']
+        
         # capture the types in case JS needs them
         types = []
 

--- a/lib/jekyll/tags/webmention.rb
+++ b/lib/jekyll/tags/webmention.rb
@@ -66,7 +66,9 @@ module Jekyll
         # Get the URI
         args = @text.split(/\s+/).map(&:strip)
         uri = context['page']['url']
-                
+        uri = args.shift
+        uri = lookup(context, uri)
+
         # capture the types in case JS needs them
         types = []
 

--- a/lib/jekyll/tags/webmention.rb
+++ b/lib/jekyll/tags/webmention.rb
@@ -65,8 +65,8 @@ module Jekyll
       def render(context)
         # Get the URI
         args = @text.split(/\s+/).map(&:strip)
-        uri = context['page']['permalink']
-        
+        uri = context['page']['url']
+                
         # capture the types in case JS needs them
         types = []
 

--- a/lib/jekyll/webmention_io/version.rb
+++ b/lib/jekyll/webmention_io/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module WebmentionIO
-    VERSION = "3.3.4"
+    VERSION = "3.3.4.1"
   end
 end

--- a/lib/jekyll/webmention_io/version.rb
+++ b/lib/jekyll/webmention_io/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module WebmentionIO
-    VERSION = "3.3.4.1"
+    VERSION = "3.3.4.2"
   end
 end

--- a/lib/jekyll/webmention_io/version.rb
+++ b/lib/jekyll/webmention_io/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module WebmentionIO
-    VERSION = "3.3.4.3"
+    VERSION = "3.3.4.4"
   end
 end

--- a/lib/jekyll/webmention_io/version.rb
+++ b/lib/jekyll/webmention_io/version.rb
@@ -2,4 +2,4 @@
 
 module Jekyll
   module WebmentionIO
-    VERSION = "3.3.4.3
+    VERSION = "3.3.4.3"

--- a/lib/jekyll/webmention_io/version.rb
+++ b/lib/jekyll/webmention_io/version.rb
@@ -3,3 +3,5 @@
 module Jekyll
   module WebmentionIO
     VERSION = "3.3.4.3"
+  end
+end

--- a/lib/jekyll/webmention_io/version.rb
+++ b/lib/jekyll/webmention_io/version.rb
@@ -2,6 +2,4 @@
 
 module Jekyll
   module WebmentionIO
-    VERSION = "3.3.4.2"
-  end
-end
+    VERSION = "3.3.4.3


### PR DESCRIPTION
For some reason the reading of the local cache was not working. I'm not very familiar with jekyll-webmention_io but i chased the bug down to the definition of `uri`.

Using `context['page']['permalink']` as the source of the cache key fixed to bug for me. Hope it helps.