### PR TITLE
Serving Webmention examples when serving site locally

### DIFF
--- a/lib/jekyll/samples/webmentions.yml
+++ b/lib/jekyll/samples/webmentions.yml
@@ -1,0 +1,61 @@
+"*":
+  '1':
+    id: '1'
+    uri: https://www.aaron-gustafson.com/
+    source: false
+    pubdate: 2020-02-10 09:09:09.000000000 +00:00
+    raw:
+      source: https://www.aaron-gustafson.com/
+      verified: true
+      verified_date: '2020-02-10T09:09:09+00:00'
+      id: 1
+      private: false
+      data:
+        author: &1
+          name: Aaron Gustafson
+          url: https://www.aaron-gustafson.com/about
+          photo: https://www.aaron-gustafson.com/i/headshots/2014.jpg
+        url: https://www.aaron-gustafson.com
+        name:
+        content:
+        published:
+        published_ts:
+      activity:
+        type: like
+        sentence:
+        sentence_html:
+      target: http://localhost:4000/mention1
+    author: *1
+    type: like
+    content: ''
+  '2':
+    id: '2'
+    uri: https://twitter.com/AaronGustafson/status/123456
+    source: twitter
+    pubdate: 2020-02-11 10:10:10.000000000 +00:00
+    raw:
+      source: https://brid-gy.appspot.com/like/twitter/AaronGustafson/123456
+      verified: true
+      verified_date: '2020-02-11T10:10:10+00:00'
+      id: 2
+      private: false
+      data:
+        author: &2
+          name: Aaron Gustafson
+          url: https://twitter.com/AaronGustafson
+          photo: https://webmention.io/avatar/pbs.twimg.com/ccecfe0f8e7fe60a7d2fa1f0524b3e73449fd5bdf62eacb7d9c3298360ca316f.jpg
+        url: https://twitter.com/AaronGustafson/status/123456
+        name:
+        content:
+        published:
+        published_ts:
+      activity:
+        type: like
+        sentence: Aaron Gustafson favorited a tweet http://localhost:4000/mention2
+        sentence_html: <a href="https://twitter.com/AaronGustafson">Aaron Gustafson</a>
+          favorited a tweet <a href="http://localhost:4000/mention2">http://localhost:4000/mention2</a>
+      target: http://localhost:4000/mention2
+    author: *2
+    type: like
+    content: <p><a href="https://twitter.com/AaronGustafson">Aaron Gustafson</a> favorited
+      a tweet <a href="http://localhost:4000/mention2">http://localhost:4000/mention2</a></p>

--- a/lib/jekyll/tags/webmention.rb
+++ b/lib/jekyll/tags/webmention.rb
@@ -16,6 +16,12 @@ module Jekyll
       def initialize(tag_name, text, tokens)
         super
         cache_file = WebmentionIO.get_cache_file_path "incoming"
+
+        if Jekyll.sites.first.config['serving'] || Jekyll.sites.first.config['url'].include?('localhost') #Jekyll.env == 'development'
+          WebmentionIO.log "info", "Running locally: returning webmention samples."
+          cache_file = File.join( File.dirname(__FILE__), '../samples/webmentions.yml')
+        end
+
         @cached_webmentions = if File.exist? cache_file
                                 WebmentionIO.load_yaml(cache_file)
                               else
@@ -67,6 +73,7 @@ module Jekyll
         args = @text.split(/\s+/).map(&:strip)
         uri = args.shift
         uri = lookup(context, uri)
+        uri = '*' if Jekyll.sites.first.config['serving'] || Jekyll.sites.first.config['url'].include?('localhost') #Jekyll.env == 'development'
 
         # capture the types in case JS needs them
         types = []


### PR DESCRIPTION
Hi Aaron,

I recently started implementing webmentions on my personal site using this repo (thank you for that!). But starting out fresh, I had no existing webmentions available to me. And this made it a little difficult to add the necessary CSS styling (and custom HTML markup) to my site, to see how they would render.

So, I added some samples that would make it easier for me in this regard.
**And now I’m wondering, if this would be something that could benefit others as well**. So, here’s my little draft PR.

If you think this would be useful, I’m happy to add more sample webmentions. I think it’d be good to have at least two of each type (“like”, “reply” etc.).
And I would continue to choose authors from the group of people that contributed to _this_ repository, to the webmention.io service, and/or promote the indieweb more generally. **Or do you think they should be something else, or fake entirely?**