### PR TITLE
Remove deprecated calls to URI.parse

### DIFF
--- a/jekyll-webmention_io.gemspec
+++ b/jekyll-webmention_io.gemspec
@@ -32,7 +32,7 @@ This Gem includes a suite of tools for managing webmentions in Jekyll:
 * Generators - Collect webmentions from Webmention.io and gather sites you’ve mentioned
 EOF
 
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.7.0"
 
   s.platform      = Gem::Platform::RUBY
   s.files         = `git ls-files app lib`.split("\n")
@@ -46,10 +46,11 @@ EOF
   s.add_runtime_dependency "uglifier", "~> 4.1"
   s.add_runtime_dependency "webmention", "~> 0.1.6"
 
-  s.add_development_dependency "bundler", "~> 1.14"
+  s.add_development_dependency "bundler", "~> 2.0"
   s.add_development_dependency "cucumber", "~> 3.1"
   s.add_development_dependency "rake", "~> 12.0"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "html-proofer", "~> 3.6"
   s.add_development_dependency "rubocop", "~> 0.48"
+  s.add_development_dependency "kramdown-parser-gfm", "~> 1.1"
 end

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -285,7 +285,7 @@ module Jekyll
         when Net::HTTPSuccess then
           return response.body.force_encoding("UTF-8")
         when Net::HTTPRedirection then
-          redirect_to = URI.parse(URI.encode(response["location"]))
+          redirect_to = URI::Parser.new.parse(response["location"])
           redirect_to = redirect_to.relative? ? "#{original_uri.scheme}://#{original_uri.host}" + redirect_to.to_s : redirect_to.to_s
           return get_uri_source(redirect_to, redirect_limit - 1, original_uri)
         else
@@ -329,7 +329,7 @@ module Jekyll
     # Private Methods
 
     def self.get_http_response(uri)
-      uri  = URI.parse(URI.encode(uri))
+      uri = URI::Parser.new.parse(uri)
       http = Net::HTTP.new(uri.host, uri.port)
       http.read_timeout = 10
 
@@ -352,7 +352,7 @@ module Jekyll
 
     # Cache bad URLs for a bit
     def self.uri_is_not_ok(uri)
-      uri = URI.parse(URI.encode(uri.to_s))
+      uri = URI::Parser.new.parse(uri.to_s)
       # Never cache webmention.io in here
       return if uri.host == "webmention.io"
 
@@ -363,7 +363,7 @@ module Jekyll
     end
 
     def self.uri_ok?(uri)
-      uri = URI.parse(URI.encode(uri.to_s))
+      uri = URI::Parser.new.parse(uri.to_s)
       now = Time.now.to_s
       bad_uris = load_yaml(@cache_files["bad_uris"])
       if bad_uris.key? uri.host


### PR DESCRIPTION
URI.parse is deprecated in Ruby 2.7+, replaced with URI::Parser.new
Updated gemspec to require ruby 2.7+
Added kramdown to development dependencies so cucumber tests would run