### PR TITLE
Implementation of new bad URI handling logic.

### DIFF
--- a/docs/bad_uri_policy.md
+++ b/docs/bad_uri_policy.md
@@ -1,0 +1,91 @@
+---
+title: "Bad URI Policy"
+---
+
+Attempts to send webmentions to a given site may fail for a few different reasons:
+
+1. The site doesn't support webmentions.
+2. The site returned an error indicating an issue with the request.
+3. The site returned a server error or there was a network connectivity issue.
+
+When an error like this occurs, this plugin tracks a record indicating the affected host, the time the attempt was made, and the number of attempts that have been made with that host.  The next time the plugin attempts to send a webmention, a configurable policy controls whether the attempt is made or skipped.  This reduces the number of unnecessary attempts made when persistent error conditions are encountered.
+
+To provide the most flexibility the plugin allows different rules to be applied depending on the type of failure encountered.  The following is an example of complete retry policy:
+
+```yml
+bad_uri_policy:
+  unsupported: ban
+  error:
+    policy: ignore
+  failure:
+    policy: retry
+    retry_delay: [ 1, 12, 48, 120 ]
+    max_retries: 5
+  whitelist:
+    - "^https://brid.gy/publish/"
+  blacklist:
+    - "^https://en.wikipedia.org/"
+```
+
+## Policy definition
+
+As illustrated in the previous example, the retry policy is broken into sections based on the error type in question.  Valid error types are:
+
+* `unsupported` - The target of the webmention does not support webmentions.
+* `error` - The target of the webmention returned an error indicating a client-side issue.
+* `failure` - The target of the webmention returned an error indicating a server-side issue, or there was a network connectivity failure.
+* `default` - Default policy applied if no policy is defined for the recorded host status.
+
+The `policy` field indicates how to treat the link based on the previous error encountered:
+
+* `ban` - Always skip sending webmentions to this host.
+* `ignore` - Always attempt to send webmentions to this host.
+* `retry` - Attempt to send webmentions based on the retry policy.
+
+The retry policy then allows the user to control when and how often to retry, and supports the following settings:
+
+* `retry_delay` - A list of *hour* delay values.  For the nth attempt, the nth value is looked up in the list, and the next attempt must occur that many hours after the previous attempt.  The last entry is used for all subsequent attempts.  If not specified, defaults to 24 hours.
+* `max_retries` - If specified, once this many attempts have been made, webmentions will no longer be sent to this host.  By default, there is no maximum.
+
+## Whitelisting and Blacklisting
+
+In some cases it's desirable to force the plugin to always (or never) send a webmention to a given URL.
+
+As a practical example, the [brid.gy](https://brid.gy) landing page does not publish webmention endpoints.  However, the service does provide specific webmention publishing endpoints.  Unfortunately, simply including the link to brid.gy in a blog post would then result in its publishing endpoints being affected (as the policy is applied to the whole host).
+
+To support these use cases, the plugin supports these settings:
+
+* `whitelist` - A list of regular expressions.  If the URI in question matches one of these patterns, the webmention will be sent.
+* `blacklist` - A list of regular expressions.  If the URI in question matches one of these patterns, the webmention will *not* be sent.
+
+Note, the pattern is matched against the whole URI and not just the host.
+
+## Default
+
+The default policy is:
+
+```yml
+bad_uri_policy:
+  default: retry
+```
+
+This is equivalent to infinite retries with a 24 delay.
+
+## cache_bad_uris_for
+
+In previous versions of this plugin the setting `cache_bad_uris_for` was used to control the behaviour of this plugin when an error occurred sending a webmention.  As per the previous documentation:
+
+>  In order to reduce unnecessary requests to servers that aren’t responding, this gem will keep track of them and avoid making new requests to them for 1 day. If you’d like to adjust this up or down, you can use this configuration value. It expects a number corresponding to the number of days you want to wait before trying the domain again.
+
+For backward compatibility, this setting is still supported.  When configured, it sets the default `retry_delay` value when the value is not specified in a given policy.  For example, this configuration:
+
+```yml
+
+cache_bad_uris_for: 5
+bad_uri_policy:
+  default:
+    policy: retry
+    max_attempts: 5
+```
+
+Will result in a retry policy that waits 5 *days* between attempts, and stops retrying after 5 attempts.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,8 @@ This gem will work well out of the box, but is configurable in a number of ways.
 * `cache_folder` - by default, this gem will cache all files in the `.jekyll-cache`, but you can specify another location (like `_data`) if you like. In order to avoid collisions, all cache files will be prefixed with “webmention_io_” unless your `cache_folder` value contains “webmention” (e.g. `.jekyll_cache/webmentions`)
 * `cache_bad_uris_for` - In order to reduce unnecessary requests to servers that aren’t responding, this gem will keep track of them and avoid making new requests to them for 1 day. If you’d like to adjust this up or down, you can use this configuration value. It expects a number corresponding to the number of days you want to wait before trying the domain again.
 * `html_proofer` - If you use the HTML Proofer gem to check your HTML, it doesn't ignore template tags, so we add the `data-proofer-ignore` attribute to the template elements to avoid showing false positives.
+* `bad_uri_policy` - In order to reduce unnecessary requests to servers that aren’t responding, this gem will keep track of them and avoid making new requests to them based on a policy you set.  See [Bad URI Policy](/jekyll-webmention_io/bad_uri_policy) for more details.
+* `max_attempts` - The bad_uri_policy settings control the behaviour of jekyll-webmention for whole hosts.  This setting allows the user to specify a maximum number of attempts to send a specific webmention before the plugin gives up.  By default this setting is disabled, meaning there is no maximum.
 * `legacy_domains` - If you’ve relocated your site from another URL or moved from to HTTPS from HTTP, you can use this configuration option to specify additional domains to append your `page.url` to. It expects an array.
 * `templates` - If you would like to roll your own templates, you totally can. You will need to assign a hash of the template paths to use for loading each one.
 * `username` - Your [webmention.io](https://webmention.io) username (for use in the `link` tags in your head)
@@ -33,6 +35,7 @@ webmentions:
   username: YOUR_USERNAME
   cache_folder: .cache
   cache_bad_uris_for: 5
+  max_attempts: 5
   legacy_domains:
     - http://aaron-gustafson.com
     - http://www.aaron-gustafson.com
@@ -44,6 +47,19 @@ webmentions:
     replies: _includes/webmentions/replies.html
     reposts: _includes/webmentions/reposts.html
     webmentions: _includes/webmentions/webmentions.html
+  bad_uri_policy:
+    unsupported:
+      policy: ban
+    error:
+      policy: ignore
+    failure:
+      policy: retry
+      retry_delay: [ 1, 12, 48, 120 ]
+      max_retries: 5
+    whitelist:
+      - "^https://brid.gy/publish/"
+    blacklist:
+      - "^https://foo.bar/"
 ```
 
 ## What’s checked

--- a/lib/jekyll/commands/webmention.rb
+++ b/lib/jekyll/commands/webmention.rb
@@ -26,13 +26,14 @@ module Jekyll
           WebmentionIO.log "msg", "Getting ready to send webmentions (this may take a while)."
 
           count = 0
+          max_attempts = WebmentionIO.max_attempts()
           cached_outgoing = WebmentionIO.get_cache_file_path "outgoing"
           if File.exist?(cached_outgoing)
             outgoing = WebmentionIO.load_yaml(cached_outgoing)
             outgoing.each do |source, targets|
               targets.each do |target, response|
                 # skip ones we’ve handled
-                next unless response == false
+                next unless response == false or response.instance_of? Integer
 
                 # convert protocol-less links
                 if target.index("//").zero?
@@ -45,6 +46,17 @@ module Jekyll
 
                 # skip bad URLs
                 next unless WebmentionIO.uri_ok?(escaped)
+
+                # give up if we've attempted this too many times
+                response = (response || 0) + 1
+
+                if ! max_attempts.nil? and response > max_attempts
+                  outgoing[source][target] = ""
+                  WebmentionIO.log "msg", "Giving up sending from #{source} to #{target}."
+                  next
+                else
+                  outgoing[source][target] = response
+                end
 
                 # get the endpoint
                 endpoint = WebmentionIO.get_webmention_endpoint(escaped)
@@ -64,9 +76,7 @@ module Jekyll
                 count += 1
               end
             end
-            if count.positive?
-              WebmentionIO.dump_yaml(cached_outgoing, outgoing)
-            end
+            WebmentionIO.dump_yaml(cached_outgoing, outgoing)
             WebmentionIO.log "msg", "#{count} webmentions sent."
           end # file exists (outgoing)
         end # def process

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -21,10 +21,24 @@ require "webmention"
 
 module Jekyll
   module WebmentionIO
+    module UriState
+      UNSUPPORTED = "unsupported"
+      ERROR = "error"
+      FAILURE = "failure"
+      SUCCESS = "success"
+    end
+
+    module UriPolicy
+      BAN = "ban"
+      IGNORE = "ignore"
+      RETRY = "retry"
+    end
+
     class << self
       # define simple getters and setters
       attr_reader :config, :jekyll_config, :cache_files, :cache_folder,
-                  :file_prefix, :types, :supported_templates, :js_handler
+                  :file_prefix, :types, :supported_templates, :js_handler,
+                  :uri_whitelist, :uri_blacklist
       attr_writer :api_suffix
     end
 
@@ -69,6 +83,18 @@ module Jekyll
       end
 
       @js_handler = WebmentionIO::JSHandler.new(site)
+
+      @uri_whitelist = @config
+        .fetch("bad_uri_policy", {})
+        .fetch("whitelist", [])
+        .clone
+        .insert(-1, "^https?://webmention.io/")
+        .map { |expr| Regexp.new(expr) }
+
+      @uri_blacklist = @config
+        .fetch("bad_uri_policy", {})
+        .fetch("blacklist", [])
+        .map { |expr| Regexp.new(expr) }
     end
 
     # Setter
@@ -79,6 +105,10 @@ module Jekyll
     # Helpers
     def self.cache_file(filename)
       Jekyll.sanitized_path(@cache_folder, "#{@file_prefix}#{filename}")
+    end
+
+    def self.max_attempts()
+      @config.dig("max_attempts")
     end
 
     def self.get_cache_file_path(key)
@@ -213,11 +243,11 @@ module Jekyll
         endpoint = IndieWeb::Endpoints.get(uri)[:webmention]
         unless endpoint
           log("info", "Could not find a webmention endpoint at #{uri}")
-          uri_is_not_ok(uri)
+          update_uri_cache(uri, UriState::UNSUPPORTED)
         end
       rescue StandardError => e
         log "info", "Endpoint lookup failed for #{uri}: #{e.message}"
-        uri_is_not_ok(uri)
+        update_uri_cache(uri, UriState::FAILURE)
         endpoint = false
       end
       endpoint
@@ -231,10 +261,12 @@ module Jekyll
       case response.code
       when 200, 201, 202
         log "info", "Webmention successful!"
+        update_uri_cache(target, UriState::SUCCESS)
         response.body
       else
         log "info", response.inspect
         log "info", "Webmention failed, but will remain queued for next time"
+        update_uri_cache(target, UriState::ERROR)
         false
       end
     end
@@ -291,12 +323,12 @@ module Jekyll
           redirect_to = redirect_to.relative? ? "#{original_uri.scheme}://#{original_uri.host}" + redirect_to.to_s : redirect_to.to_s
           return get_uri_source(redirect_to, redirect_limit - 1, original_uri)
         else
-          uri_is_not_ok(uri)
+          update_uri_cache(uri, UriState::FAILURE)
           return false
         end
       else
         log("warn", "too many redirects for #{original_uri}") if original_uri
-        uri_is_not_ok(uri)
+        update_uri_cache(uri, UriState::FAILURE)
         return false
       end
     end
@@ -347,37 +379,176 @@ module Jekyll
         return response
       rescue *EXCEPTIONS => e
         log "warn", "Got an error checking #{uri}: #{e}"
-        uri_is_not_ok(uri)
+        update_uri_cache(uri, UriState::FAILURE)
         return false
       end
     end
 
-    # Cache bad URLs for a bit
-    def self.uri_is_not_ok(uri)
+    # Given the provided state value (see UriState), retrieve the policy
+    # entry.  If no entry exists, return a new default entry that
+    # indicates unlimited retries.
+    def self.get_bad_uri_policy_entry(state)
+      settings = @config.fetch("bad_uri_policy", {})
+
+      default_policy = { "policy" => UriPolicy::RETRY }
+      policy_entry = nil
+
+      # Retrieve the policy entry, the default entry, or the canned default
+      policy_entry = settings.fetch(state) {
+        settings.fetch("default", default_policy)
+      }
+
+      # Convert shorthand entry to full policy record
+      if policy_entry.instance_of? String
+        policy_entry = { "policy" => policy_entry }
+      end
+
+      if policy_entry["policy"] == UriPolicy::RETRY and ! policy_entry.key? "retry_delay"
+        # If this is a retry policy and no delay is set, set up the default
+        # delay policy.  This inherits from the legacy cache_bad_uris_for
+        # setting to enable backward compatibility with older configurations.
+        #
+        # We do this here to make the rule enforcement logic a little tidier.
+
+        policy_entry["retry_delay"] = [ @config.fetch("cache_bad_uris_for", 1) * 24 ]
+      end
+
+      return policy_entry
+    end
+
+    # Retrieve the bad_uris cache entry for the given URI.  This method
+    # takes the cache and a URI instance (i.e. parsing must already be done).
+    #
+    # If the URI has no entry in the cache, returns nil and *not* a default
+    # entry.
+    def self.get_bad_uri_cache_entry(bad_uris, uri)
+      return nil if ! bad_uris.key? uri.host
+
+      entry = bad_uris[uri.host].clone
+
+      if entry.instance_of? String
+        # Older version of the bad URL cache, convert to new format with some
+        # "sensible" defaults.
+
+        entry = {
+          "state" => UriState::UNSUPPORTED,
+          "last_checked" => DateTime.parse(entry).to_time,
+          "attempts" => 1
+        }
+      else
+        # Otherwise, parse the check time into a real Time object before
+        # returning the entry.
+        #
+        # We convert to a Time object so we can do arithmetic on it later.
+
+        entry["last_checked"] = DateTime.parse(entry["last_checked"]).to_time
+      end
+
+      return entry
+    end
+
+    # Update the URI cache for this entry.
+    #
+    # If the state is UriState.SUCCESS or the URI is whitelisted or
+    # blacklisted, we delete any existing entries since no policy will
+    # apply.  This ensures we reset the policy state when a webmention
+    # succeeds.
+    #
+    # Otherwise, we either create or update an entry for the URI, recording
+    # the state and the current attempt counter.
+    def self.update_uri_cache(uri, state)
       uri = URI::Parser.new.parse(uri.to_s)
-      # Never cache webmention.io in here
-      return if uri.host == "webmention.io"
+      uri_str = uri.to_s
 
       cache_file = @cache_files["bad_uris"]
       bad_uris = load_yaml(cache_file)
-      bad_uris[uri.host] = Time.now.to_s
+
+      if state == UriState::SUCCESS or
+          @uri_whitelist.any? { |expr| expr.match uri_str } or
+          @uri_blacklist.any? { |expr| expr.match uri_str }
+
+        return if bad_uris.delete(uri.host).nil?
+      else
+        old_entry = get_bad_uri_cache_entry(bad_uris, uri) || {}
+
+        bad_uris[uri.host] = {
+          "state" => state,
+          "attempts" => old_entry.fetch("attempts", 0) + 1,
+          "last_checked" => Time.now.to_s
+        }
+      end
+
       dump_yaml(cache_file, bad_uris)
     end
 
+    # Check if we should attempt to send a webmention to the given URI based
+    # on the error handling policy and the last attempt.
     def self.uri_ok?(uri)
       uri = URI::Parser.new.parse(uri.to_s)
       now = Time.now.to_s
+      uri_str = uri.to_s
+
+      # If the URI is whitelisted, it's always ok!
+      return true if @uri_whitelist.any? { |expr| expr.match uri_str }
+
+      # If the URI is blacklisted, it's never ok!
+      return false if @uri_blacklist.any? { |expr| expr.match uri_str }
+
       bad_uris = load_yaml(@cache_files["bad_uris"])
-      if bad_uris.key? uri.host
-        last_checked = DateTime.parse(bad_uris[uri.host])
-        cache_bad_uris_for = @config["cache_bad_uris_for"] || 1 # in days
-        recheck_at = last_checked.next_day(cache_bad_uris_for).to_s
-        return false if recheck_at > now
+      entry = get_bad_uri_cache_entry(bad_uris, uri)
+
+      # If the entry isn't in our cache yet, then it's ok.
+      return true if entry.nil?
+
+      # Okay, the last time we tried to send a webmention to this URI it
+      # failed, so depending on what happened and the policy, we need to
+      # decide what to do.
+      #
+      # First pull the retry policy given the type of the last error for the URI
+      policy_entry = get_bad_uri_policy_entry(entry["state"])
+      policy = policy_entry["policy"]
+
+      if policy == UriPolicy::BAN
+        return false
+      elsif policy == UriPolicy::IGNORE
+        return true
+      elsif policy == UriPolicy::RETRY
+        now = Time.now
+
+        attempts = entry["attempts"]
+        max_attempts = policy_entry["max_attempts"]
+
+        if ! max_attempts.nil? and attempts >= max_attempts
+          # If there's a retry limit and we've hit it, URI is not ok.
+          log "msg", "Skipping #{uri}, attempted #{attempts} times and max is #{max_attempts}"
+
+          return false
+        end
+
+        retry_delay = policy_entry["retry_delay"]
+
+        # Sneaky trick.  By clamping to the array length, the last entry in
+        # the retry_delay list is used for all remaining retries.
+        delay = retry_delay[(attempts - 1).clamp(0, retry_delay.length - 1)]
+
+        recheck_at = (entry["last_checked"] + delay * 3600)
+
+        if recheck_at.to_r > now.to_r
+          log "msg", "Skipping #{uri}, next attempt will happen after #{recheck_at}"
+
+          return false
+        end
+      else
+        log "error", "Invalid bad URI policy type: #{policy}"
       end
+
       return true
     end
 
-    private_class_method :get_http_response, :uri_is_not_ok
+    private_class_method :get_http_response,
+                         :get_bad_uri_policy_entry,
+                         :get_bad_uri_cache_entry,
+                         :update_uri_cache
   end
 end
 


### PR DESCRIPTION
This changeset is intended to resolve #129.  Here we implement a much more flexible policy mechanism for handling URIs for which the plugin previous experienced errors sending a webmention.

Errors are classified into three different categories (unsupported, error, failure), and separate policies can be defined for each, allowing the user a lot of control over how the plugin treats these conditions.

Additionally, while the plugin currently has a feature to control retries for whole hosts, what it lacks is a mechanism to have the plugin give up on individual webmentions.

This commit introduces a new max_attempts setting which, if set, will cause the plugin to give up and mark a webmention as sent after a configured number of tries.