### PR TITLE
Fixing a bug by breaking a feature

### DIFF
--- a/lib/jekyll/commands/webmention.rb
+++ b/lib/jekyll/commands/webmention.rb
@@ -35,10 +35,8 @@ module Jekyll
                 # skip ones we’ve handled
                 next unless response == false or response.instance_of? Integer
 
-                # convert protocol-less links
-                if target.index("//").zero?
-                  target = "http:#{target}"
-                end
+                # skip protocol-less links, we'll need to revisit this again later
+                next if target.index("//").zero?
 
                 # produce an escaped version of the target (in case of special
                 # characters, etc).


### PR DESCRIPTION
I don't understand the need to support sending webmentions for protocol-less links, and this code is busted: it results in the target hash table changing while we're in the middle of iterating over it (since the 'target' key value gets modified and a new has entry inserted).

If this is really needed we can always revisit later and refactor the code so it works.