### PR TITLE
Syndication

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ webmentions:
     twitter: 
       endpoint: https://brid.gy/publish/twitter
       response_mapping:
-        url: syndication
+        syndication: $.url
     github: 
       endpoint: https://brid.gy/publish/github
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ This gem will work well out of the box, but is configurable in a number of ways.
 * `legacy_domains` - If you’ve relocated your site from another URL or moved from to HTTPS from HTTP, you can use this configuration option to specify additional domains to append your `page.url` to. It expects an array.
 * `templates` - If you would like to roll your own templates, you totally can. You will need to assign a hash of the template paths to use for loading each one.
 * `username` - Your [webmention.io](https://webmention.io) username (for use in the `link` tags in your head)
-* `syndication_endpoints` - A list of key-value pairs representing standard targets for [syndication](/jekyll-webmention_io/syndication)
+* `syndication` - A set of endpoints to use for [syndication](/jekyll-webmention_io/syndication)
 
 ## Simple Example
 
@@ -61,9 +61,13 @@ webmentions:
       - "^https://brid.gy/publish/"
     blacklist:
       - "^https://foo.bar/"
-  syndication_endpoints:
-    twitter: https://brid.gy/publish/twitter
-    github: https://brid.gy/publish/github
+  syndication:
+    twitter: 
+      endpoint: https://brid.gy/publish/twitter
+      response_mapping:
+        url: syndication
+    github: 
+      endpoint: https://brid.gy/publish/github
 ```
 
 ## What’s checked

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ This gem will work well out of the box, but is configurable in a number of ways.
 * `legacy_domains` - If you’ve relocated your site from another URL or moved from to HTTPS from HTTP, you can use this configuration option to specify additional domains to append your `page.url` to. It expects an array.
 * `templates` - If you would like to roll your own templates, you totally can. You will need to assign a hash of the template paths to use for loading each one.
 * `username` - Your [webmention.io](https://webmention.io) username (for use in the `link` tags in your head)
+* `syndication_endpoints` - A list of key-value pairs representing standard targets for [syndication](/jekyll-webmention_io/syndication)
 
 ## Simple Example
 
@@ -60,6 +61,9 @@ webmentions:
       - "^https://brid.gy/publish/"
     blacklist:
       - "^https://foo.bar/"
+  syndication_endpoints:
+    twitter: https://brid.gy/publish/twitter
+    github: https://brid.gy/publish/github
 ```
 
 ## What’s checked

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ If you want to dive right in, read the [Quickstart](/jekyll-webmention_io/quicks
 Other topics you might be interested in:
 
 * **[Configuration](/jekyll-webmention_io/configuration)** - How to configure your installation
+* **[Syndication](/jekyll-webmention_io/syndication)** - How to configure your blog for easy syndication to standard locations
 * **[Performance Tuning](/jekyll-webmention_io/performance-tuning)** - How to speed up (or at least manage) your build time
 * **[Debugging](/jekyll-webmention_io/debugging)** - Print debugging info to the command line
 

--- a/docs/syndication.md
+++ b/docs/syndication.md
@@ -74,7 +74,7 @@ Receivers of webmentions require that the source page where the webmention origi
 
 ```
 {% for target in page.syndicate_to %}
-  <a href="{{ site.webmentions.syndication_endpoints[target] }}"></a>
+  <a href="{{ site.webmentions.syndication[target].endpoint }}"></a>
 {% endfor %}
 ```
 

--- a/docs/syndication.md
+++ b/docs/syndication.md
@@ -9,6 +9,7 @@ To enable syndication to services supporting webmention, this plugin includes so
 1. A set of short-hand syndication endpoints, specified in your site configuration
 2. Additional front matter in the page that indicates where to send webmentions
 3. Additional material in your layout template to automatically include the endpoint URL in the page
+4. Support for pulling data from syndication endpoint JSON responses into the page front matter for display
 
 ## Site configuration
 
@@ -16,12 +17,44 @@ The first part of the setup is to configure your syndication endpoints:
 
 ```yml
 webmentions:
-  syndication_endpoints:
-    twitter: https://brid.gy/publish/twitter
-    github: https://brid.gy/publish/github
+  syndication:
+    twitter: 
+      endpoint: https://brid.gy/publish/twitter
+    github: 
+      endpoint: https://brid.gy/publish/github
 ```
 
 Each endpoint includes a shorthand name and the URL to send the webmention to.  In this case, we're configuring our system to send webmentions to Brid.gy for automated syndication.
+
+## Response mapping
+
+Some syndication endpoints return JSON responses which contain important information about the syndicated post.
+
+This plugin supports defining a mapping from data in the response to keys in the front matter for the page.  For example:
+
+```yml
+webmentions:
+  syndication:
+    twitter: 
+      endpoint: https://brid.gy/publish/twitter
+      response_mapping:
+        url: syndication
+        user.screen_name: username
+```
+
+The keys in the `response_mapping` map represent paths to values in the JSON response.  The values are the names of keys in the page front matter where the data will be stored.
+
+Note:  If multiple endpoints are specified that map a response value to the same front matter key, the result will be an array of values in the front matter.
+
+These values can then be used in the page layout.  For example, the following snippet will use the `url` front matter property defined above to create links to the syndicated content:
+
+```
+{%- for url in page.syndication -%}
+  <a class="u-syndication" href="{{ url }}">{{ url }}</a>
+{%- endfor -%}
+```
+
+If you're curious what is present in the endpoint responses that you might be able to use, you can find the raw webmention responses in the webmention_io_outgoing.yml file in your cache directory.
 
 ## Front matter
 

--- a/docs/syndication.md
+++ b/docs/syndication.md
@@ -90,13 +90,13 @@ webmentions:
     twitter: 
       endpoint: https://brid.gy/publish/twitter
       response_mapping:
-        url: syndication
-        user.screen_name: username
+        syndication: $.url
+        username: $.user.screen_name: 
 ```
 
-The keys in the `response_mapping` map represent paths to values in the JSON response.  The values are the names of keys in the page front matter where the data will be stored.
+The keys in the `response_mapping` map represent the names of keys that will be populated in the page front matter.  The values are [JsonPath](https://goessner.net/articles/JsonPath/) expressions that return the value for the key.  If the expression returns a single value, that value will be used to populate the front matter.  Otherwise, the set of values will be stored as an array.
 
-Note:  If multiple endpoints are specified that map a response value to the same front matter key, the result will be an array of values in the front matter.
+Note:  If multiple endpoints are specified that map a response value to the same front matter key, the result will be a flattened array of values.
 
 These values can then be used in the page layout.  For example, the following snippet will use the `url` front matter property defined above to create links to the syndicated content:
 

--- a/docs/syndication.md
+++ b/docs/syndication.md
@@ -26,6 +26,58 @@ webmentions:
 
 Each endpoint includes a shorthand name and the URL to send the webmention to.  In this case, we're configuring our system to send webmentions to Brid.gy for automated syndication.
 
+## Post syndication
+
+Once syndication targets have been set up, you must provide Jekyll with instructions as to where to syndicate each page.  Syndication is controlled in one of two ways:
+
+1. Page front matter
+2. Collection configuration
+
+Note, these can be combined.  If you specify syndication targets in both front matter and collections, the results are combined and webmentions are sent to all endpoints that apply for the page in question.
+
+### Front matter
+
+If a page contains a "syndicate_to" key in its front matter, the value is assumed to be an array which contains the names of one or more endpoints to send webmentions to.  For example:
+
+```yml
+---
+layout: post
+date:   2019-11-18 09:49:09 -0700
+syndicate_to: [ twitter, github ]
+---
+```
+
+Alternatively, this can also be controlled via the `defaults` Jekyll configuration.  For example:
+
+```yml
+defaults:
+  -
+    scope:
+      path: "microblog"
+    values:
+      syndicate_to: [ twitter, github ]
+```
+
+### Collections
+
+As an alternative to used `defaults`, you can also instruct the plugin to syndicate whole collections as follows:
+
+```yml
+collections:
+  posts:
+    syndicate_to: [ twitter, github ]
+```
+
+## Layout
+
+Receivers of webmentions require that the source page where the webmention originates include a link to the target page.  To automate this, some additional material should be added to the page layout (the simplest would be to add this to the common header or footer):
+
+```
+{% for target in page.syndicate_to %}
+  <a href="{{ site.webmentions.syndication_endpoints[target] }}"></a>
+{% endfor %}
+```
+
 ## Response mapping
 
 Some syndication endpoints return JSON responses which contain important information about the syndicated post.
@@ -56,24 +108,3 @@ These values can then be used in the page layout.  For example, the following sn
 
 If you're curious what is present in the endpoint responses that you might be able to use, you can find the raw webmention responses in the webmention_io_outgoing.yml file in your cache directory.
 
-## Front matter
-
-Each post must then include an additional `syndicate_to` key which specifies an array of one or more endpoints to send webmentions to:
-
-```yml
----
-layout: post
-date:   2019-11-18 09:49:09 -0700
-syndicate_to: [ twitter, github ]
----
-```
-
-## Layout
-
-Receivers of webmentions require that the source page where the webmention originates include a link to the target page.  To automate this, some additional material should be added to the page layout (the simplest would be to add this to the common header or footer):
-
-```
-{% for target in page.syndicate_to %}
-  <a href="{{ site.webmentions.syndication_endpoints[target] }}"></a>
-{% endfor %}
-```

--- a/docs/syndication.md
+++ b/docs/syndication.md
@@ -1,0 +1,46 @@
+---
+title: "Syndication"
+---
+
+A core concept of [POSSE](https://indieweb.org/POSSE) is the syndication of content from your blog to [silos](https://indieweb.org/silo) such as Twitter, Github, and so forth.  Syndication is often done manually, but services like [Brid.gy](https://brid.gy/) make it possible to automate the process using webmentions.  Additionally, sites like [IndieNews](https://news.indieweb.org/) make it possible to publish links to the service in the same way.
+
+To enable syndication to services supporting webmention, this plugin includes some convenience configuration that makes it easy to indicate common webmention targets that you'd like to use for posts.  This mechanism comes in the form of:
+
+1. A set of short-hand syndication endpoints, specified in your site configuration
+2. Additional front matter in the page that indicates where to send webmentions
+3. Additional material in your layout template to automatically include the endpoint URL in the page
+
+## Site configuration
+
+The first part of the setup is to configure your syndication endpoints:
+
+```yml
+webmentions:
+  syndication_endpoints:
+    twitter: https://brid.gy/publish/twitter
+    github: https://brid.gy/publish/github
+```
+
+Each endpoint includes a shorthand name and the URL to send the webmention to.  In this case, we're configuring our system to send webmentions to Brid.gy for automated syndication.
+
+## Front matter
+
+Each post must then include an additional `syndicate_to` key which specifies an array of one or more endpoints to send webmentions to:
+
+```yml
+---
+layout: post
+date:   2019-11-18 09:49:09 -0700
+syndicate_to: [ twitter, github ]
+---
+```
+
+## Layout
+
+Receivers of webmentions require that the source page where the webmention originates include a link to the target page.  To automate this, some additional material should be added to the page layout (the simplest would be to add this to the common header or footer):
+
+```
+{% for target in page.syndicate_to %}
+  <a href="{{ site.webmentions.syndication_endpoints[target] }}"></a>
+{% endfor %}
+```

--- a/jekyll-webmention_io.gemspec
+++ b/jekyll-webmention_io.gemspec
@@ -45,6 +45,7 @@ EOF
   s.add_runtime_dependency "htmlbeautifier", "~> 1.1"
   s.add_runtime_dependency "uglifier", "~> 4.1"
   s.add_runtime_dependency "webmention", "~> 7.0"
+  s.add_runtime_dependency "jsonpath", "~> 1.0.1"
 
   s.add_development_dependency "bundler", "~> 2.2"
   s.add_development_dependency "cucumber", "~> 3.1"

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -48,7 +48,38 @@ module Jekyll
 
       private
 
-      def process_syndication(post, uri, target, response)
+      def compile_jsonpath_expressions()
+        @syndication.each do | target, config |
+          next if ! config.key? "response_mapping"
+
+          mapping = config["response_mapping"]
+
+          mapping.clone.each do | key, pattern |
+            begin
+              mapping[key] = JsonPath.new(pattern)
+            rescue StandardError => e
+              WebmentionIO.log "error", "Ignoring invalid JsonPath expression #{pattern}: #{e}"
+
+              mapping.delete(key)
+            end
+          end
+        end
+      end
+
+      def combine_values(a, b)
+        return case [ a.instance_of?(Array), b.instance_of?(Array) ]
+          when [ false, false ]
+            [ a, b ]
+          when [ false, true ]
+            [ a ] + b
+          when [ true, false ]
+            a << b
+          when [ true, true ]
+            a + b
+        end
+      end
+
+      def process_syndication(post, target, response)
         # If this is a syndication target, and we have a response,
         # and the syndication entry contains a response mapping, then
         # go through that map and store the selected values into
@@ -64,7 +95,7 @@ module Jekyll
             else
               # Uhoh!  The path doesn't exist, so throw an error and
               # give up on this mapping entry
-              WebmentionIO.log "msg", "The path #{skey} doesn't exist in the response from #{target['endpoint']} for #{uri}"
+              WebmentionIO.log "msg", "The path #{skey} doesn't exist in the response from #{target['endpoint']} for #{post.url}"
 
               value = nil
               break
@@ -93,35 +124,44 @@ module Jekyll
         return nil
       end
 
+      def get_syndication_target(uri)
+        return nil if @syndication.nil?
+
+        @syndication.values.detect { |t| t["endpoint"] == uri }
+      end
+
       def gather_webmentions(posts)
         webmentions = WebmentionIO.read_cached_webmentions "outgoing"
 
         posts.each do |post|
-          uri = File.join(@site_url, post.url)
+          # Collect potential outgoing webmentions in this post.
           mentions = get_mentioned_uris(post)
-          if webmentions.key? uri
-            mentions.each do |mentioned_uri, response|
-              if webmentions[uri].key? mentioned_uri
-                # We knew about this target from a previous run
 
-                next if @syndication.nil?
+          mentions.each do |mentioned_uri, response|
+            # If this webmention was a product of a syndication instruction,
+            # this goes back into the configuration and pulls that syndication
+            # target config out.
+            #
+            # If this is just a normal webmention, this will return nil.
+            target = get_syndication_target(mentioned_uri)
 
-                target = @syndication.values.detect { |t|
-                  t["endpoint"] == mentioned_uri
-                }
+            fulluri = File.join(@site_url, post.url)
+            shorturi = post.data["shorturl"] || fulluri
 
-                response = webmentions[uri][mentioned_uri]
+            # Old cached responses might use either the full or short URIs so
+            # we need to check for both.
+            cached_response =
+              webmentions.dig(shorturi, mentioned_uri) ||
+              webmentions.dig(fulluri, mentioned_uri)
 
-                if ! target.nil? and target.key? "response_mapping"
-                  process_syndication(post, uri, target, response)
-                end
-              else
-                # This is a new mention, add the target to the cache
-                webmentions[uri][mentioned_uri] = response
-              end
+            if cached_response.nil?
+              uri = (! target.nil? and target["shorturl"]) ? shorturi : fulluri
+
+              webmentions[uri] ||= {}
+              webmentions[uri][mentioned_uri] = response
+            elsif ! target.nil? and target.key? "response_mapping"
+              process_syndication(post, target, cached_response)
             end
-          else
-            webmentions[uri] = mentions
           end
         end
 

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -41,8 +41,7 @@ module Jekyll
 
         upgrade_outgoing_webmention_cache
 
-        posts = WebmentionIO.gather_documents(@site)
-
+        posts = WebmentionIO.gather_documents(@site).select { |p| ! p.data["draft"] }
         gather_webmentions(posts)
       end
 

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -115,9 +115,9 @@ module Jekyll
 
       def get_collection_for_post(post)
         @site.collections.each do |name, collection|
-          if collection.docs.include? post
-            return collection
-          end
+          next if name == "posts"
+
+          return collection if collection.docs.include? post
         end
 
         return nil
@@ -174,7 +174,10 @@ module Jekyll
 
         syndication_targets = []
         syndication_targets += post.data["syndicate_to"] || []
-        syndication_targets += collection.metadata["syndicate_to"] || []
+
+        if ! collection.nil?
+          syndication_targets += collection.metadata["syndicate_to"] || []
+        end
 
         syndication_targets.each do |endpoint|
           if @syndication.key? endpoint

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -34,14 +34,9 @@ module Jekyll
           return
         end
 
-        if @site.config.dig("webmentions", "pause_lookups")
-          WebmentionIO.log "info", "Webmention lookups are currently paused."
-          return
-        end
-
         compile_jsonpath_expressions() if ! @syndication.nil?
 
-        WebmentionIO.log "msg", "Beginning to gather webmentions you’ve made. This may take a while."
+        WebmentionIO.log "msg", "Collecting webmentions you’ve made. This may take a while."
 
         upgrade_outgoing_webmention_cache
 
@@ -167,7 +162,16 @@ module Jekyll
           end
         end
 
-        WebmentionIO.cache_webmentions "outgoing", webmentions
+        # This check is moved down here because we still need the steps
+        # above to populate frontmatter during the site build, even
+        # if we're not going to modify the webmention cache.
+
+        if @site.config.dig("webmentions", "pause_lookups")
+          WebmentionIO.log "info", "Webmention lookups are currently paused."
+          return
+        else
+          WebmentionIO.cache_webmentions "outgoing", webmentions
+        end
       end
 
       def get_mentioned_uris(post)

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -149,7 +149,15 @@ module Jekyll
               webmentions.dig(fulluri, mentioned_uri)
 
             if cached_response.nil?
-              uri = (! target.nil? and target["shorturl"]) ? shorturi : fulluri
+              if ! target.nil?
+                uri = target["shorturl"] ? shorturi : fulluri
+
+                if target.key? "fragment"
+                  uri += "#" + target["fragment"]
+                end
+              else
+                uri = fulluri
+              end
 
               webmentions[uri] ||= {}
               webmentions[uri][mentioned_uri] = response

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -191,6 +191,11 @@ module Jekyll
         if post.data["in_reply_to"]
           uris[post.data["in_reply_to"]] = false
         end
+
+        if post.data["bookmark_of"]
+          uris[post.data["bookmark_of"]] = false
+        end
+
         post.content.scan(/(?:https?:)?\/\/[^\s)#\[\]{}<>%|\^"']+/) do |match|
           unless uris.key? match
             uris[match] = false

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -17,6 +17,7 @@ module Jekyll
       def generate(site)
         @site = site
         @site_url = site.config["url"].to_s
+        @syndication_endpoints = site.config.dig("webmentions", "syndication_endpoints")
 
         if @site.config['serving']
           Jekyll::WebmentionIO.log "msg", "Webmentions lookups are not run when running `jekyll serve`."
@@ -69,6 +70,15 @@ module Jekyll
 
       def get_mentioned_uris(post)
         uris = {}
+        if post.data["syndicate_to"]
+          post.data["syndicate_to"].each do |endpoint|
+            if @syndication_endpoints.key? endpoint
+              uris[@syndication_endpoints[endpoint]] = false
+            else
+              WebmentionIO.log "msg", "Found reference to syndication endpoint \"#{endpoint}\" without matching entry in configuration."
+            end
+          end
+        end
         if post.data["in_reply_to"]
           uris[post.data["in_reply_to"]] = false
         end

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -104,6 +104,8 @@ module Jekyll
               if webmentions[uri].key? mentioned_uri
                 # We knew about this target from a previous run
 
+                next if @syndication.nil?
+
                 target = @syndication.values.detect { |t|
                   t["endpoint"] == mentioned_uri
                 }

--- a/lib/jekyll/generators/queue_webmentions.rb
+++ b/lib/jekyll/generators/queue_webmentions.rb
@@ -56,7 +56,29 @@ module Jekyll
           mentions = get_mentioned_uris(post)
           if webmentions.key? uri
             mentions.each do |mentioned_uri, response|
-              unless webmentions[uri].key? mentioned_uri
+              if webmentions[uri].key? mentioned_uri
+                # We knew about this target from a previous run
+
+                cached_response = webmentions[uri][mentioned_uri]
+
+                if ! @syndication_endpoints.values.index(mentioned_uri).nil? and
+                    cached_response.instance_of? Hash and
+                    cached_response.key? "url"
+
+                  # If this is a syndication target, and we have a response,
+                  # then the response might include the syndication URL (e.g.
+                  # with brid.gy).  Here we pull that out if it exists and add
+                  # it to the "syndication" front matter element so that it can
+                  # be used in templates.
+
+                  post.data["syndication"] ||= []
+
+                  if post.data["syndication"].instance_of? Array
+                    post.data["syndication"].insert(-1, cached_response["url"])
+                  end
+                end
+              else
+                # This is a new mention, add the target to the cache
                 webmentions[uri][mentioned_uri] = response
               end
             end

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -266,6 +266,18 @@ module Jekyll
       else
         log "info", response.inspect
         log "info", "Webmention failed, but will remain queued for next time"
+
+        if response.body
+          begin
+            body = JSON.parse(response.body)
+
+            if body.key? "error"
+              log "msg", "Endpoint returned error: #{body['error']}"
+            end
+          rescue
+          end
+        end
+
         update_uri_cache(target, UriState::ERROR)
         false
       end


### PR DESCRIPTION
A core concept of [POSSE](https://indieweb.org/POSSE) is the syndication of content from your blog to [silos](https://indieweb.org/silo) such as Twitter, Github, and so forth.  Syndication is often done manually, but services like [Brid.gy](https://brid.gy/) make it possible to automate the process using webmentions.

To enable syndication to services supporting webmention, this PR implements  convenience configuration that makes it easy to indicate common webmention targets that you'd like to use for posts.

This implements the ideas originally discussed in issue #132 .