### PR TITLE
Ruby 3.2 support

### DIFF
--- a/jekyll-webmention_io.gemspec
+++ b/jekyll-webmention_io.gemspec
@@ -41,7 +41,7 @@ EOF
   s.add_runtime_dependency "jekyll", ">= 3.2.0", "< 5.0"
   s.add_runtime_dependency "json", "~> 2.0"
   s.add_runtime_dependency "openssl", ">= 2.0", "< 4.0"
-  s.add_runtime_dependency "string_inflection", "~> 0.1"
+  s.add_runtime_dependency "activesupport", "~> 7.0", ">= 7.0.4.3"
   s.add_runtime_dependency "htmlbeautifier", "~> 1.1"
   s.add_runtime_dependency "uglifier", "~> 4.1"
   s.add_runtime_dependency "webmention", "~> 7.0"
@@ -49,7 +49,7 @@ EOF
 
   s.add_development_dependency "bundler", "~> 2.2"
   s.add_development_dependency "cucumber", "~> 3.1"
-  s.add_development_dependency "rake", "~> 12.0"
+  s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "html-proofer", "~> 3.6"
   s.add_development_dependency "rubocop", "~> 0.48"

--- a/lib/jekyll/generators/compile_js.rb
+++ b/lib/jekyll/generators/compile_js.rb
@@ -18,7 +18,6 @@ module Jekyll
       end
     end
 
-    using StringInflection
     class CompileJS < Generator
       safe true
       priority :low
@@ -61,7 +60,7 @@ module Jekyll
       def add_webmention_types
         js_types = []
         WebmentionIO.types.each do |type|
-          js_types.push "'#{type}': '#{type.to_singular}'"
+          js_types.push "'#{type}': '#{ActiveSupport::Inflector.singularize(type)}'"
         end
         types_js = <<-EOF
           ;(function(window,JekyllWebmentionIO){

--- a/lib/jekyll/tags/webmention.rb
+++ b/lib/jekyll/tags/webmention.rb
@@ -11,7 +11,6 @@ require "htmlbeautifier"
 
 module Jekyll
   module WebmentionIO
-    using StringInflection
     class WebmentionTag < Liquid::Tag
       def initialize(tag_name, text, tokens)
         super
@@ -50,7 +49,7 @@ module Jekyll
         if !WebmentionIO.types.include? type
           WebmentionIO.log "warn", "#{type} are not extractable"
         else
-          type = type.to_singular
+          type = ActiveSupport::Inflector.singularize(type)
           WebmentionIO.log "info", "Searching #{webmentions.length} webmentions for type==#{type}"
           if webmentions.is_a? Hash
             webmentions = webmentions.values

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -15,7 +15,7 @@ require "json"
 require "net/http"
 require "uri"
 require "openssl"
-require "string_inflection"
+require "active_support"
 require "indieweb/endpoints"
 require "webmention"
 


### PR DESCRIPTION
While upgrading my Jekyll-build sites to Ruby 3.2, I noticed this gem is not compatible. Here’s more info, which I wrote in the commit message:

> Replacing `string_inflection` gem with `activesupport`
> 
> `string_inflection` was incompatible with Ruby `3.2`: `.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/string_inflection-0.1.2/lib/string_inflection.rb:11:in 'include': Refinement#include has been removed (TypeError)`
> 
> instead of using string_inflection's `to_singular` method, now using `ActiveSupport::Inflector.singularize`
> 
> Had to upgrade `rake` from v12 to v13 due to general dependency conflicts.

I decided to not try and update the [long-unmaintained `0.x`-version `string_inflection` gem](https://github.com/mosop/string_inflection-ruby) and instead go with the much more stable and maintained `ActiveSupport`.

However, including this much new code (also) seems overkill for just being able to use its `singularize` method. If I’m not mistaken, “only” the webmention _types_ need to be singularized. And when looking [at what seems to be the type-list](https://github.com/aarongustafson/jekyll-webmention_io/blob/main/lib/jekyll/webmention_io.rb#L51), one could also simply get away with removing any trailing `”s”`-es, and thereby get rid of any inflection-dependency altogether. Or not!? Anyhow, in this PR, I kept using string inflection. But I’d be happy to alternatively try and suggest a solution without inflection library.