### PR TITLE
Add an end-to-end webmention round-trip smoke test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,16 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+# Fast unit suite: everything except the end-to-end smoke tests.
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = '--tag ~integration'
+end
 
-task default: :spec
+# End-to-end smoke test. Boots local WEBrick servers to stand in for the
+# webmention receiver and the webmention.io API -- no external services.
+RSpec::Core::RakeTask.new(:integration) do |t|
+  t.pattern = 'spec/integration/**/*_spec.rb'
+  t.rspec_opts = '--tag integration'
+end
+
+task default: %i[spec integration]

--- a/jekyll-webmention_io.gemspec
+++ b/jekyll-webmention_io.gemspec
@@ -58,4 +58,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'rubocop', '~> 1.81'
   s.add_development_dependency 'timecop', '~> 0.9'
+  s.add_development_dependency 'webrick', '~> 1.7'
 end

--- a/lib/jekyll/assets/webmention_loader.js
+++ b/lib/jekyll/assets/webmention_loader.js
@@ -24,10 +24,12 @@
     redirects = false;
   }
 
-  // Load up any unpublished webmentions on load
+  // Load up any unpublished webmentions on load. The API base is injected at
+  // build time (see CompileJS#add_config); fall back to webmention.io.
   $script = document.createElement('script');
   $script.async = true;
-  $script.src = 'https://webmention.io/api/mentions?' +
+  $script.src = ( window.JekyllWebmentionIO.api_base || 'https://webmention.io/api' ) +
+                '/mentions?' +
                 'jsonp=window.JekyllWebmentionIO.processWebmentions&target[]=' +
                 targets.join( '&target[]=' );
   document.querySelector('head').appendChild( $script );

--- a/lib/jekyll/config.rb
+++ b/lib/jekyll/config.rb
@@ -28,7 +28,12 @@ module Jekyll
       attr_accessor :html_proofer_ignore, :max_attempts,
                     :templates, :bad_uri_policy, :throttle_lookups, :cache_folder,
                     :legacy_domains, :pause_lookups, :site_url, :syndication, :js,
-                    :username, :debug
+                    :username, :debug, :api_url
+
+      # The default base URL for the Webmention.io API. Exposed as a config key
+      # so the endpoint can be pointed elsewhere (e.g. a local stand-in during
+      # integration testing) instead of being hard-coded in the network layer.
+      DEFAULT_API_URL = 'https://webmention.io/api'
 
       def initialize(site = nil)
         @site = site
@@ -46,6 +51,7 @@ module Jekyll
         @site_url = site_url
         @username = config['username']
         @debug = config['debug']
+        @api_url = config['api_url'] || DEFAULT_API_URL
 
         @pause_lookups =
           if !@site.nil? && @site.config['serving']

--- a/lib/jekyll/config.rb
+++ b/lib/jekyll/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 module Jekyll
   module WebmentionIO
     class Config
@@ -30,10 +32,29 @@ module Jekyll
                     :legacy_domains, :pause_lookups, :site_url, :syndication, :js,
                     :username, :debug, :api_url
 
+      # The scheme://host[:port] origin and bare host of the configured API,
+      # derived from api_url. Used to build the service links emitted into the
+      # page head (and the JS) so they track a custom endpoint instead of being
+      # hard-coded to webmention.io.
+      attr_reader :api_origin, :api_host
+
       # The default base URL for the Webmention.io API. Exposed as a config key
       # so the endpoint can be pointed elsewhere (e.g. a local stand-in during
       # integration testing) instead of being hard-coded in the network layer.
       DEFAULT_API_URL = 'https://webmention.io/api'
+
+      # Resolves a webmention API URL to a URI, falling back to the default
+      # endpoint when the configured value has no host.
+      def self.api_uri(url)
+        uri = URI.parse(url)
+        uri.host ? uri : URI.parse(DEFAULT_API_URL)
+      end
+
+      # The host of a parsed API URI, plus the port when it isn't the scheme's
+      # default (so custom/local endpoints still match the full URL).
+      def self.authority(uri)
+        uri.port == uri.default_port ? uri.host : "#{uri.host}:#{uri.port}"
+      end
 
       def initialize(site = nil)
         @site = site
@@ -52,6 +73,9 @@ module Jekyll
         @username = config['username']
         @debug = config['debug']
         @api_url = config['api_url'] || DEFAULT_API_URL
+        api_uri = self.class.api_uri(@api_url)
+        @api_host = api_uri.host
+        @api_origin = "#{api_uri.scheme}://#{self.class.authority(api_uri)}"
 
         @pause_lookups =
           if !@site.nil? && @site.config['serving']
@@ -150,10 +174,12 @@ module Jekyll
           @bad_uri_policy['whitelist'] ||= []
           @bad_uri_policy['blacklist'] ||= []
 
-          # We always want to collection webmentions from webmention.io, so we
-          # explicitly flag it. This way if there's a service outage, we don't
-          # end up banning the URL.
-          @bad_uri_policy['whitelist'].insert(-1, '^https?://webmention.io/')
+          # We always want to collect webmentions from the configured API host,
+          # so we explicitly whitelist it. This way a transient service outage
+          # won't get the endpoint banned by the bad-URI policy. Derived from the
+          # configured api_url (default webmention.io) so a custom endpoint gets
+          # the same protection.
+          @bad_uri_policy['whitelist'].insert(-1, api_host_pattern(site_config))
 
           @whitelist = @bad_uri_policy['whitelist'].map { |expr| Regexp.new(expr) }
           @blacklist = @bad_uri_policy['blacklist'].map { |expr| Regexp.new(expr) }
@@ -197,6 +223,17 @@ module Jekyll
             policy_entry['max_attempts'],
             policy_entry['retry_delay']
           )
+        end
+
+        private
+
+        # Builds an anchored host pattern for the configured webmention API so it
+        # is always exempt from the bad-URI policy, mirroring the api_url read in
+        # Config#parse. A non-default port is included so custom/local endpoints
+        # still match the full URL the network layer checks.
+        def api_host_pattern(site_config)
+          uri = Config.api_uri(site_config['api_url'] || DEFAULT_API_URL)
+          "^https?://#{Regexp.escape(Config.authority(uri))}/"
         end
       end
 

--- a/lib/jekyll/generators/compile_js.rb
+++ b/lib/jekyll/generators/compile_js.rb
@@ -9,6 +9,7 @@
 
 require 'uglifier'
 require 'fileutils'
+require 'json'
 require 'active_support'
 
 module Jekyll
@@ -48,6 +49,7 @@ module Jekyll
 
         @javascript = +'' # unfrozen String
 
+        add_config
         concatenate_asset_files
         add_webmention_types
 
@@ -57,6 +59,19 @@ module Jekyll
       end
 
       private
+
+      # Injects build-time configuration onto the global before any asset runs,
+      # so the loader (which executes synchronously) can read the configured API
+      # base instead of a hard-coded webmention.io URL.
+      def add_config
+        config_js = <<-CONFIG_JS
+          ;(function(window){
+            if ( ! ( 'JekyllWebmentionIO' in window ) ){ window.JekyllWebmentionIO = {}; }
+            window.JekyllWebmentionIO.api_base = #{WebmentionIO.config.api_url.to_json};
+          }(this));
+        CONFIG_JS
+        @javascript << config_js
+      end
 
       def add_webmention_types
         js_types = WebmentionIO.types.map do |type|

--- a/lib/jekyll/tags/webmentions_head.rb
+++ b/lib/jekyll/tags/webmentions_head.rb
@@ -11,13 +11,16 @@ module Jekyll
   module WebmentionIO
     class WebmentionHeadTag < Liquid::Tag
       def render(context)
+        config = WebmentionIO.config
+        origin = config.api_origin
+
         head = +'' # unfrozen String
-        head << '<link rel="dns-prefetch" href="https://webmention.io">'
-        head << '<link rel="preconnect" href="https://webmention.io">'
-        head << '<link rel="preconnect" href="ws://webmention.io:8080">'
+        head << "<link rel=\"dns-prefetch\" href=\"#{origin}\">"
+        head << "<link rel=\"preconnect\" href=\"#{origin}\">"
+        head << "<link rel=\"preconnect\" href=\"ws://#{config.api_host}:8080\">"
 
         page = context['page']
-        site_url = WebmentionIO.config.site_url
+        site_url = config.site_url
 
         if page['redirect_from']
           if page['redirect_from'].is_a? String
@@ -28,11 +31,11 @@ module Jekyll
           head << "<meta property=\"webmention:redirected_from\" content=\"#{redirect}\">"
         end
 
-        username = WebmentionIO.config.username
+        username = config.username
 
         if username
-          head << "<link rel=\"pingback\" href=\"https://webmention.io/#{username}/xmlrpc\">"
-          head << "<link rel=\"webmention\" href=\"https://webmention.io/#{username}/webmention\">"
+          head << "<link rel=\"pingback\" href=\"#{origin}/#{username}/xmlrpc\">"
+          head << "<link rel=\"webmention\" href=\"#{origin}/#{username}/webmention\">"
         end
 
         head

--- a/lib/jekyll/webmention_io.rb
+++ b/lib/jekyll/webmention_io.rb
@@ -33,7 +33,7 @@ module Jekyll
       @config = config || Config.new(@site)
       @caches = caches || Caches.new(@config)
       @policy = policy || WebmentionPolicy.new(@config, @caches)
-      @webmentions = webmentions || Webmentions.new(@policy)
+      @webmentions = webmentions || Webmentions.new(@policy, NetworkClient.new, @config.api_url)
       @templates = templates || Templates.new(site)
 
       @js_handler = WebmentionIO::JSHandler.new

--- a/lib/jekyll/webmentions.rb
+++ b/lib/jekyll/webmentions.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'config'
 require_relative 'network_client'
 
 module Jekyll
@@ -12,7 +13,7 @@ module Jekyll
       # that is used to perform low-level network operations, and a set of
       # parameters that specifies the endpoint URL, path, and query parameters
       # to use.
-      def initialize(policy, client = NetworkClient.new, url = 'https://webmention.io/api', path = 'mentions', suffix = '&perPage=9999')
+      def initialize(policy, client = NetworkClient.new, url = Config::DEFAULT_API_URL, path = 'mentions', suffix = '&perPage=9999')
         @policy = policy
         @client = client
 

--- a/spec/compile_js_spec.rb
+++ b/spec/compile_js_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe Jekyll::WebmentionIO::CompileJS do
+  include_context 'webmention_io_stubs'
+
+  let(:tmp) { Dir.mktmpdir('compile_js_spec') }
+  let(:site) { instance_double('Jekyll::Site') }
+  let(:generator) { described_class.new }
+  let(:compiled_js) { File.read(File.join(tmp, 'js', 'JekyllWebmentionIO.js')) }
+
+  before do
+    # uglify off so the assertions can read the un-minified output (and we don't
+    # need a JS runtime); deploy off so we don't touch site.static_files.
+    config.parse({ 'api_url' => 'http://localhost:9999/api',
+                   'js' => { 'uglify' => false, 'deploy' => false } })
+    allow(site).to receive(:config).and_return({})
+    allow(site).to receive(:in_source_dir).and_return(tmp)
+  end
+
+  after { FileUtils.rm_rf(tmp) }
+
+  it 'injects the configured api_base onto the global' do
+    generator.generate(site)
+
+    expect(compiled_js).to include('window.JekyllWebmentionIO.api_base = "http://localhost:9999/api"')
+  end
+
+  it 'sets api_base before the loader reads it' do
+    generator.generate(site)
+
+    assignment = compiled_js.index('api_base =')
+    usage = compiled_js.index('api_base ||')
+
+    expect(assignment).to be < usage
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -97,6 +97,53 @@ RSpec.describe Jekyll::WebmentionIO::Config do
     end
   end
 
+  context 'with the default api_url' do
+    let(:webmentions_config) { {} }
+
+    it 'defaults to the webmention.io endpoint' do
+      expect(config.api_url).to eq 'https://webmention.io/api'
+    end
+
+    it 'derives the service origin and host' do
+      expect(config.api_origin).to eq 'https://webmention.io'
+      expect(config.api_host).to eq 'webmention.io'
+    end
+
+    it 'whitelists the default api host and nothing else' do
+      whitelist = config.bad_uri_policy.whitelist
+      expect(whitelist.any? { |re| re.match?('https://webmention.io/foo') }).to be true
+      expect(whitelist.any? { |re| re.match?('https://evil.example/foo') }).to be false
+    end
+  end
+
+  context 'with a custom api_url' do
+    let(:webmentions_config) { { 'api_url' => 'http://127.0.0.1:9999/api' } }
+
+    it 'uses the configured api_url' do
+      expect(config.api_url).to eq 'http://127.0.0.1:9999/api'
+    end
+
+    it 'derives the service origin (with port) and host' do
+      expect(config.api_origin).to eq 'http://127.0.0.1:9999'
+      expect(config.api_host).to eq '127.0.0.1'
+    end
+
+    it 'whitelists the configured api host, not webmention.io' do
+      whitelist = config.bad_uri_policy.whitelist
+      expect(whitelist.any? { |re| re.match?('http://127.0.0.1:9999/api') }).to be true
+      expect(whitelist.any? { |re| re.match?('https://webmention.io/foo') }).to be false
+    end
+  end
+
+  context 'with a host-less api_url' do
+    let(:webmentions_config) { { 'api_url' => '/mentions' } }
+
+    it 'falls back to the default endpoint origin and host' do
+      expect(config.api_origin).to eq 'https://webmention.io'
+      expect(config.api_host).to eq 'webmention.io'
+    end
+  end
+
   context 'with a full js config' do
     let(:webmentions_config) do
       {

--- a/spec/integration/smoke_spec.rb
+++ b/spec/integration/smoke_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require_relative 'support/test_server'
+require_relative 'support/static_server'
+require_relative 'support/webmention_hub'
+require_relative 'support/jekyll_site_builder'
+
+# End-to-end smoke test for the webmention round trip, with no external services
+# in the loop. A local hub plays both the receiver and the webmention.io read
+# API; a local static server hosts the built site.
+#
+# The send and receive paths are exercised as separate examples so a failure
+# points at exactly one half of the cycle. To keep them independent, the receive
+# example seeds the hub directly rather than relying on the send example having
+# run first, and the hub is cleared before each example.
+RSpec.describe 'Webmention round trip', :integration do
+  before(:all) do
+    @root = Dir.mktmpdir('webmention-smoke')
+    @hub = SmokeTest::WebmentionHub.new(SmokeTest.free_port).start
+    @site_port = SmokeTest.free_port
+
+    @builder = SmokeTest::JekyllSiteBuilder.new(
+      root: @root,
+      site_origin: "http://127.0.0.1:#{@site_port}",
+      hub_endpoint: @hub.endpoint,
+      hub_api_url: @hub.api_url
+    )
+    @builder.write_sources
+
+    # Build once up front so there's a `_site` for the static server to host and
+    # an outgoing-webmention cache for the send example to act on.
+    build_site
+    @static = SmokeTest::StaticServer.new(@site_port, @builder.destination).start
+  end
+
+  after(:all) do
+    @static&.stop
+    @hub&.stop
+    FileUtils.remove_entry(@root) if @root && File.directory?(@root)
+    Jekyll::WebmentionIO::Caches.reset
+  end
+
+  before { @hub.clear }
+
+  # Each phase mirrors a fresh CLI invocation: reset the cache singletons so
+  # state is reloaded from disk, then let the `:after_init` hook re-bootstrap
+  # the plugin against the site's configuration.
+  def build_site
+    Jekyll::WebmentionIO::Caches.reset
+    Jekyll::Site.new(@builder.configuration).process
+  end
+
+  def run_webmention_command
+    Jekyll::WebmentionIO::Caches.reset
+    Jekyll::Site.new(@builder.configuration)
+    Jekyll::WebmentionIO::Commands::WebmentionCommand.send_webmentions
+  end
+
+  # Leg A: the queued webmention is sent and the receiver verifies it.
+  it 'sends a queued webmention that the receiver verifies and stores' do
+    run_webmention_command
+
+    mention = @hub.mentions.find do |m|
+      m.source == @builder.source_url && m.target == @builder.target_url
+    end
+    expect(mention).not_to(be_nil, 'the hub never received a verified webmention from the source post')
+  end
+
+  # Leg B: a received webmention is gathered back via the read API and rendered.
+  it 'gathers a received webmention and renders it into the page' do
+    @hub.seed(source: @builder.source_url, target: @builder.target_url)
+
+    build_site
+
+    rendered = File.read(@builder.target_output)
+    expect(rendered).to include(@builder.source_url)
+    expect(rendered).to include(SmokeTest::WebmentionHub::MENTION_CONTENT)
+    expect(rendered).not_to include('No webmentions were found')
+  end
+end

--- a/spec/integration/support/jekyll_site_builder.rb
+++ b/spec/integration/support/jekyll_site_builder.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'jekyll'
+
+module SmokeTest
+  # Writes a minimal, self-contained Jekyll site into a scratch directory and
+  # hands back a Jekyll configuration for building it. The site is deliberately
+  # tiny -- two posts and a layout -- but wired for a full round trip:
+  #
+  #   * the source post links to the target post (drives leg A: sending), and
+  #   * the target post advertises the hub as its webmention endpoint and renders
+  #     the {% webmentions %} tag (drives leg B: receiving + rendering).
+  #
+  # Ports are dynamic, so the source post's link to the target is written as a
+  # literal absolute URL -- the queue generator scans raw post content for URLs
+  # before Liquid runs, so a `{{ site.url }}` reference wouldn't be found.
+  class JekyllSiteBuilder
+    SOURCE_PERMALINK = '/source/'
+    TARGET_PERMALINK = '/target/'
+
+    attr_reader :root, :site_origin, :source_url, :target_url
+
+    def initialize(root:, site_origin:, hub_endpoint:, hub_api_url:)
+      @root = root
+      @site_origin = site_origin
+      @hub_endpoint = hub_endpoint
+      @hub_api_url = hub_api_url
+      @source_url = "#{site_origin}#{SOURCE_PERMALINK}"
+      @target_url = "#{site_origin}#{TARGET_PERMALINK}"
+    end
+
+    def write_sources
+      write('_config.yml', config_yml)
+      write('_layouts/default.html', layout_html)
+      write('_posts/2001-01-01-source-post.md', source_post)
+      write('_posts/2001-01-02-target-post.md', target_post)
+    end
+
+    def configuration
+      Jekyll.configuration(
+        'source' => @root,
+        'destination' => destination,
+        'quiet' => true
+      )
+    end
+
+    def destination
+      File.join(@root, '_site')
+    end
+
+    # Where Jekyll writes the rendered target post (permalink => /target/index.html).
+    def target_output
+      File.join(destination, 'target', 'index.html')
+    end
+
+    private
+
+    def write(relative_path, contents)
+      path = File.join(@root, relative_path)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, contents)
+    end
+
+    def config_yml
+      <<~YAML
+        url: "#{@site_origin}"
+        webmention_endpoint: "#{@hub_endpoint}"
+        webmentions:
+          api_url: "#{@hub_api_url}"
+          pause_lookups: false
+          js: false
+      YAML
+    end
+
+    def layout_html
+      <<~HTML
+        <!doctype html>
+        <html>
+          <head>
+            <title>{{ page.title }}</title>
+            <link rel="webmention" href="{{ site.webmention_endpoint }}">
+          </head>
+          <body>
+            {{ content }}
+          </body>
+        </html>
+      HTML
+    end
+
+    def source_post
+      <<~MARKDOWN
+        ---
+        layout: default
+        title: The Source Post
+        permalink: #{SOURCE_PERMALINK}
+        ---
+        This post mentions [the target post](#{@target_url}).
+      MARKDOWN
+    end
+
+    def target_post
+      <<~MARKDOWN
+        ---
+        layout: default
+        title: The Target Post
+        permalink: #{TARGET_PERMALINK}
+        ---
+        Webmentions for this post:
+
+        {% webmentions page.url %}
+      MARKDOWN
+    end
+  end
+end

--- a/spec/integration/support/static_server.rb
+++ b/spec/integration/support/static_server.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'webrick'
+require_relative 'test_server'
+
+module SmokeTest
+  # Serves a built Jekyll `_site` over HTTP so the webmention client can fetch
+  # the source document (for endpoint discovery and the receiver's source/target
+  # verification). Plain static file serving -- nothing webmention-specific here.
+  class StaticServer
+    include ServerControl
+
+    attr_reader :port, :origin
+
+    def initialize(port, document_root)
+      @port = port
+      @origin = "http://127.0.0.1:#{port}"
+      @server = WEBrick::HTTPServer.new(
+        {
+          BindAddress: '127.0.0.1',
+          Port: port,
+          DocumentRoot: document_root,
+        }.merge(ServerControl.quiet_options)
+      )
+    end
+  end
+end

--- a/spec/integration/support/test_server.rb
+++ b/spec/integration/support/test_server.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'socket'
+require 'webrick'
+
+module SmokeTest
+  # Grab an ephemeral port from the OS and immediately release it. There's a
+  # small TOCTOU window before our server claims it, but it's good enough for a
+  # localhost test harness and beats hard-coding ports that collide in CI.
+  def self.free_port
+    socket = TCPServer.new('127.0.0.1', 0)
+    socket.addr[1]
+  ensure
+    socket&.close
+  end
+
+  # Shared start/stop plumbing for the throwaway WEBrick servers used by the
+  # integration suite. Mixing classes provide a configured @server.
+  module ServerControl
+    READINESS_TIMEOUT = 5 # seconds
+
+    def start
+      @thread = Thread.new { @server.start }
+      wait_until_listening
+      self
+    end
+
+    def stop
+      @server&.shutdown
+      @thread&.join
+    end
+
+    # Quiet WEBrick down -- the suite's output is noisy enough already.
+    def self.quiet_options
+      { Logger: WEBrick::Log.new(File::NULL), AccessLog: [] }
+    end
+
+    private
+
+    # WEBrick binds its listening socket in the constructor, but the accept loop
+    # only spins up in #start. Poll a real connection so callers never race the
+    # server's first request.
+    def wait_until_listening
+      deadline = Time.now + READINESS_TIMEOUT
+
+      loop do
+        TCPSocket.new('127.0.0.1', @port).close
+        return
+      rescue Errno::ECONNREFUSED
+        raise "server on port #{@port} never came up" if Time.now > deadline
+
+        sleep 0.05
+      end
+    end
+  end
+end

--- a/spec/integration/support/webmention_hub.rb
+++ b/spec/integration/support/webmention_hub.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'time'
+require 'webrick'
+require_relative 'test_server'
+
+module SmokeTest
+  # A self-contained stand-in for both halves of the webmention.io service, so
+  # the integration suite never has to touch the network:
+  #
+  #   * a spec-compliant Webmention *receiver* at POST /webmention -- it does
+  #     real source-links-to-target verification before accepting a mention; and
+  #   * a webmention.io-compatible *read API* at GET /api/mentions, returning
+  #     received mentions in the JSON shape WebmentionItem expects.
+  #
+  # Receiving and then serving the same mentions back is what lets the smoke
+  # test exercise a genuine round trip rather than a mocked handshake.
+  #
+  # See https://www.w3.org/TR/webmention/ and
+  # https://github.com/aaronpk/webmention.io#api.
+  class WebmentionHub
+    include ServerControl
+
+    # Canned content echoed back in the read API so the spec has a stable string
+    # to assert against in the rendered page.
+    MENTION_CONTENT = 'This webmention was delivered by the smoke-test hub.'
+    MENTION_AUTHOR = 'Smoke Tester'
+
+    Mention = Struct.new(:id, :source, :target, :verified_at, keyword_init: true)
+
+    attr_reader :port, :origin, :endpoint, :api_url
+
+    def initialize(port)
+      @port = port
+      @origin = "http://127.0.0.1:#{port}"
+      @endpoint = "#{@origin}/webmention"
+      @api_url = "#{@origin}/api"
+
+      @mentions = []
+      @mutex = Mutex.new
+      @next_id = 1000
+
+      @server = WEBrick::HTTPServer.new(
+        {
+          BindAddress: '127.0.0.1',
+          Port: port,
+        }.merge(ServerControl.quiet_options)
+      )
+      @server.mount_proc('/webmention') { |req, res| receive(req, res) }
+      @server.mount_proc('/api/mentions') { |req, res| serve_api(req, res) }
+    end
+
+    # A thread-safe snapshot of everything the receiver has accepted.
+    def mentions
+      @mutex.synchronize { @mentions.dup }
+    end
+
+    # Inject a mention directly, bypassing the HTTP receive path. Lets the
+    # read-API/render test stand on its own rather than depending on the send
+    # test having run (and succeeded) first.
+    def seed(source:, target:)
+      record(source, target)
+      self
+    end
+
+    # Forget every recorded mention so one example can't leak state into the
+    # next.
+    def clear
+      @mutex.synchronize { @mentions.clear }
+    end
+
+    private
+
+    # POST /webmention -- the receiver endpoint advertised by target pages.
+    def receive(request, response)
+      return respond(response, 405, 'error' => 'method not allowed') unless request.request_method == 'POST'
+
+      source = request.query['source']
+      target = request.query['target']
+
+      return respond(response, 400, 'error' => 'source and target are required') unless source && target
+      return respond(response, 400, 'error' => 'source does not link to target') unless source_links_to_target?(source, target)
+
+      record(source, target)
+      respond(response, 201, 'result' => 'accepted')
+    end
+
+    # GET /api/mentions -- the webmention.io read API used at build time.
+    def serve_api(request, response)
+      wanted = requested_targets(request.query_string)
+      links = mentions.select { |mention| wanted.include?(mention.target) }.map { |mention| link_for(mention) }
+
+      respond(response, 200, 'links' => links)
+    end
+
+    def record(source, target)
+      @mutex.synchronize do
+        @next_id += 1
+        @mentions << Mention.new(id: @next_id, source: source, target: target, verified_at: Time.now)
+      end
+    end
+
+    # Spec verification: fetch the source document and confirm it actually links
+    # to the target. This is what makes leg A a real test -- the plugin has to
+    # emit a page that genuinely mentions the target.
+    def source_links_to_target?(source, target)
+      body = http_get(source)
+      body ? body.include?(target) : false
+    end
+
+    def http_get(url)
+      response = Net::HTTP.get_response(URI(url))
+      response.is_a?(Net::HTTPSuccess) ? response.body : nil
+    rescue StandardError
+      nil
+    end
+
+    # webmention.io repeats the target parameter as `target[]=...`. WEBrick's
+    # parsed query collapses duplicate keys, so pull them straight from the raw
+    # query string instead.
+    def requested_targets(query_string)
+      (query_string || '').split('&').filter_map do |pair|
+        key, value = pair.split('=', 2)
+        next unless value
+
+        decoded_key = WEBrick::HTTPUtils.unescape(key).sub(/\[\]\z/, '')
+        WEBrick::HTTPUtils.unescape(value) if decoded_key == 'target'
+      end
+    end
+
+    # Shape a stored mention like a webmention.io API entry. The fields here are
+    # exactly those WebmentionItem reads (see webmention_item.rb).
+    def link_for(mention)
+      {
+        'id' => mention.id,
+        'source' => mention.source,
+        'target' => mention.target,
+        'verified_date' => mention.verified_at.iso8601,
+        'activity' => { 'type' => 'link' },
+        'data' => {
+          'url' => mention.source,
+          'name' => 'A mention from the test hub',
+          'content' => MENTION_CONTENT,
+          'published_ts' => mention.verified_at.to_i,
+          'author' => { 'name' => MENTION_AUTHOR, 'url' => mention.source },
+        },
+      }
+    end
+
+    def respond(response, status, payload)
+      response.status = status
+      response['Content-Type'] = 'application/json'
+      response.body = JSON.generate(payload)
+    end
+  end
+end

--- a/spec/webmention_head_tag_spec.rb
+++ b/spec/webmention_head_tag_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Jekyll::WebmentionIO::WebmentionHeadTag do
+  include_context 'webmention_io_stubs'
+
+  let(:page) { {} }
+  let(:context) { Struct.new(:page, :line_number, :registers).new(page, 1, {}) }
+  let(:tag) { described_class.parse(nil, '', nil, context) }
+
+  context 'with the default (webmention.io) endpoint' do
+    before { config.parse({ 'username' => 'aaron' }) }
+
+    it 'emits service links pointing at webmention.io' do
+      head = tag.render(context)
+
+      expect(head).to include('<link rel="dns-prefetch" href="https://webmention.io">')
+      expect(head).to include('<link rel="preconnect" href="https://webmention.io">')
+      expect(head).to include('<link rel="preconnect" href="ws://webmention.io:8080">')
+      expect(head).to include('<link rel="pingback" href="https://webmention.io/aaron/xmlrpc">')
+      expect(head).to include('<link rel="webmention" href="https://webmention.io/aaron/webmention">')
+    end
+  end
+
+  context 'with a custom api_url' do
+    before { config.parse({ 'api_url' => 'http://localhost:9999/api', 'username' => 'aaron' }) }
+
+    it 'derives the service links from the configured origin' do
+      head = tag.render(context)
+
+      expect(head).to include('<link rel="dns-prefetch" href="http://localhost:9999">')
+      expect(head).to include('<link rel="preconnect" href="ws://localhost:8080">')
+      expect(head).to include('<link rel="pingback" href="http://localhost:9999/aaron/xmlrpc">')
+      expect(head).to include('<link rel="webmention" href="http://localhost:9999/aaron/webmention">')
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a self-contained integration smoke test that exercises the full webmention send/receive cycle with **no external services** in the loop.

- A local **WEBrick hub** plays both roles of webmention.io: a spec-compliant **receiver** (`POST /webmention`, with real source-links-to-target verification) and the **read API** (`GET /api/mentions`, returning mentions in the JSON shape `WebmentionItem` expects). Receiving and then serving the same mentions back is what makes a genuine round trip possible rather than a mocked handshake.
- A small **static server** hosts the built `_site`, and a **builder** writes a minimal fixture Jekyll site (a source post linking to a target post; the target advertises the hub and renders `{% webmentions %}`).
- The send and receive paths are **separate examples** so a failure points at exactly one half of the cycle. The receive example seeds the hub directly to stay independent of the send path, and the hub is cleared between examples.

## Why

The suite had unit coverage but no end-to-end test proving a webmention can actually be sent, verified, gathered back, and rendered. This closes that gap without depending on webmention.io or any network.

## Supporting change

Makes the webmention.io API base URL configurable via `webmentions.api_url` (default unchanged: `https://webmention.io/api`), plumbed through `bootstrap` into the existing injectable `Webmentions` constructor — so the endpoint can be pointed at the local hub instead of being hard-coded in the network layer.

## Tooling

- New `rake integration` task, kept separate from the fast unit run (`rake spec` excludes `:integration`); default `rake` runs both, so CI picks it up with no workflow change.
- Adds `webrick` as an explicit dev dependency (previously only transitive).

## Test plan

- `bundle exec rake` — unit suite + integration, green.
- `bundle exec rspec spec/integration/smoke_spec.rb` — 2 examples, 0 failures; stable across randomized ordering (confirms the two examples are independent).
- RuboCop clean on all changed/new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)